### PR TITLE
Make the "resolve" target depend on "init-ivy"

### DIFF
--- a/test/build.xml
+++ b/test/build.xml
@@ -30,7 +30,7 @@
     <!-- ================================= 
           target: resolve              
          ================================= -->
-    <target name="resolve" description="--> retrieve dependencies with ivy">
+    <target name="resolve" depends="init-ivy" description="--> retrieve dependencies with ivy">
         <ivy:retrieve />
     </target>
     <target name="clean" description="--> clean the last build">


### PR DESCRIPTION
Without this fix, cmake fails to execute the ant build with the following error:

[afield@localhost build]$ cmake -DHOTROD_JBOSS_HOME=/home/afield/Development/tools/infinispan-server-6.0.0.Alpha3 -DNOENABLE_WARNING_ERROR=ON /home/afield/Development/projects/infinispan-cpp-client-master/
-- The C compiler identification is GNU 4.8.1
-- The CXX compiler identification is GNU 4.8.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Found Java: /usr/java/default/bin/java (found version "1.7.0.21") 
-- got runtime /usr/java/default/bin/java
-- Found JNI: /usr/java/default/jre/lib/amd64/libjawt.so  
-- Using JNI libraries: /usr/java/default/jre/lib/amd64/libjawt.so;/usr/java/default/jre/lib/amd64/server/libjvm.so
-- Found SWIG: /usr/bin/swig (found version "2.0.10") 

BUILD FAILED
/home/afield/Development/projects/infinispan-cpp-client-master/build/jni/build.xml:34: Problem: failed to create task or type antlib:org.apache.ivy.ant:retrieve
Cause: The name is undefined.
Action: Check the spelling.
Action: Check that any custom tasks/types have been declared.
Action: Check that any <presetdef>/<macrodef> declarations have taken place.
No types or tasks have been defined in this namespace yet

This appears to be an antlib declaration. 
Action: Check that the implementing library exists in one of:
        -/usr/share/ant/lib
        -/home/afield/.ant/lib
        -a directory added on the command line with the -lib argument

Total time: 0 seconds
-- Configuring done
-- Generating done
-- Build files have been written to: /home/afield/Development/projects/infinispan-cpp-client-master/build
