### PR TITLE
HRCPP-27 Correctly initialize protocol version

### DIFF
--- a/src/hotrod/impl/configuration/ConfigurationBuilder.cpp
+++ b/src/hotrod/impl/configuration/ConfigurationBuilder.cpp
@@ -11,7 +11,7 @@ namespace hotrod {
 const char* ConfigurationBuilder::PROTOCOL_VERSION_12 = "1.2";
 
 ConfigurationBuilder::ConfigurationBuilder()
-: internalPingOnStartup(true), internalTcpNoDelay(true)
+: internalPingOnStartup(true), internalProtocolVersion(PROTOCOL_VERSION_12), internalTcpNoDelay(true)
 {
   ConfigurationBuilder::connectionPoolConfigurationBuilder = ConnectionPoolConfigurationBuilder();
   ConfigurationBuilder::sslConfigurationBuilder = SslConfigurationBuilder();

--- a/src/hotrod/impl/protocol/CodecFactory.cpp
+++ b/src/hotrod/impl/protocol/CodecFactory.cpp
@@ -10,19 +10,25 @@ namespace infinispan {
 namespace hotrod {
 namespace protocol {
 
-bool CodecFactory::initialized = false;
-std::map<std::string, Codec*> CodecFactory::codecMap;
+CodecFactory::CodecFactory() {
+    codecMap[Configuration::PROTOCOL_VERSION_12] = new Codec12();
+}
 
+CodecFactory::~CodecFactory() {
+    for (std::map<std::string, Codec*>::iterator it=codecMap.begin(); it!=codecMap.end(); ++it) {
+        delete it->second;
+    }
+}
+
+CodecFactory& CodecFactory::getInstance() {
+    static CodecFactory instance;
+
+    return instance;
+}
 
 Codec* CodecFactory::getCodec(const char* version) {
-    if(!initialized) {
-        codecMap[Configuration::PROTOCOL_VERSION_12] = new Codec12();
-        initialized = true;
-    }
-
-    Codec* result = CodecFactory::codecMap[version];
-
-    return result;
+    return CodecFactory::getInstance().codecMap[version];
 }
+
 
 }}} // namespace

--- a/src/hotrod/impl/protocol/CodecFactory.h
+++ b/src/hotrod/impl/protocol/CodecFactory.h
@@ -16,11 +16,12 @@ class CodecFactory
 {
   public:
     static Codec* getCodec(const char* version);
+    static CodecFactory& getInstance();
 
   private:
     CodecFactory();
-    static std::map<std::string, Codec*> codecMap;
-    static bool initialized;
+    ~CodecFactory();
+    std::map<std::string, Codec*> codecMap;
 };
 
 }}} // namespace infinispan::hotrod::protocol

--- a/src/hotrod/impl/transport/tcp/GenericKeyedObjectPool.h
+++ b/src/hotrod/impl/transport/tcp/GenericKeyedObjectPool.h
@@ -84,7 +84,7 @@ template <class K, class V> class GenericKeyedObjectPool
         if (val) {
             factory.destroyObject(key, *val);
         }
-        poolMap.erase(key);
+        poolMap[key] = 0;
     }
 
     void preparePool(const K& key) {

--- a/src/hotrod/impl/transport/tcp/Socket.cpp
+++ b/src/hotrod/impl/transport/tcp/Socket.cpp
@@ -14,19 +14,21 @@ namespace hotrod {
 
 namespace transport {
 
-// TODO
-
 Socket::Socket() :
-    socket(*sys::Socket::create()), inputStream(socket), outputStream(socket)
+    socket(sys::Socket::create()), inputStream(*socket), outputStream(*socket)
 {}
 
+Socket::~Socket() {
+    delete socket;
+}
+
 void Socket::connect(const std::string& host, int port) {
-	std::cout << "host " << host << " port " << port << std::endl;
-    socket.connect(host, port);
+    std::cout << "host " << host << " port " << port << std::endl;
+    socket->connect(host, port);
 }
 
 void Socket::close() {
-    socket.close();
+    socket->close();
 }
 
 InputStream& Socket::getInputStream() {

--- a/src/hotrod/impl/transport/tcp/Socket.h
+++ b/src/hotrod/impl/transport/tcp/Socket.h
@@ -47,13 +47,14 @@ class Socket
 {
   public:
     Socket();
+    ~Socket();
     void connect(const std::string& host, int port);
     void close();
     InputStream& getInputStream();
     OutputStream& getOutputStream();
 
   private:
-    sys::Socket& socket;
+    sys::Socket *socket;
     InputStream inputStream;
     OutputStream outputStream;
 

--- a/src/hotrod/impl/transport/tcp/TcpTransport.cpp
+++ b/src/hotrod/impl/transport/tcp/TcpTransport.cpp
@@ -115,7 +115,6 @@ void TcpTransport::readBytes(hrbytes& bytes, uint32_t size) {
 
 void TcpTransport::release() {
     try {
-        //socket->close();
         socket.close();
     } catch(Exception& e) {
         invalid = true;
@@ -128,8 +127,6 @@ void TcpTransport::invalidate() {
 }
 
 void TcpTransport::destroy() {
-    // TODO
-    //socket->close();
     socket.close();
 }
 

--- a/src/hotrod/impl/transport/tcp/TcpTransportFactory.h
+++ b/src/hotrod/impl/transport/tcp/TcpTransportFactory.h
@@ -6,6 +6,7 @@
 #include "hotrod/impl/transport/Transport.h"
 #include "hotrod/impl/transport/TransportFactory.h"
 #include "hotrod/impl/transport/tcp/TcpTransport.h"
+#include "hotrod/impl/transport/tcp/TransportObjectFactory.h"
 #include "hotrod/sys/Mutex.h"
 
 #include <vector>
@@ -50,6 +51,7 @@ class TcpTransportFactory : public TransportFactory
     int soTimeout;
     int connectTimeout;
     int transportCount;
+    TransportObjectFactory *transportFactory;
     GenericKeyedObjectPool<InetSocketAddress, TcpTransport>* connectionPool;
     RequestBalancingStrategy* balancer;
 

--- a/src/hotrod/sys/Socket.h
+++ b/src/hotrod/sys/Socket.h
@@ -14,6 +14,7 @@ class Socket
   public:
     static Socket* create();
 
+    virtual ~Socket() {};
     virtual void connect(const std::string& host, int port) = 0;
     virtual void close() = 0;
     virtual size_t read(char *p, size_t n) = 0;

--- a/src/hotrod/sys/posix/Socket.cpp
+++ b/src/hotrod/sys/posix/Socket.cpp
@@ -35,6 +35,8 @@ namespace posix {
 class Socket: public infinispan::hotrod::sys::Socket {
   public:
     Socket();
+
+    virtual ~Socket();
     virtual void connect(const std::string& host, int port);
     virtual void close();
     virtual size_t read(char *p, size_t n);
@@ -65,7 +67,9 @@ void throwIOErr (const std::string& host, int port, const char *msg, int errnum)
 
 } /* namespace */
 
-Socket::Socket() : fd(-1) {}
+Socket::Socket() : fd(-1), port(-1) {}
+
+Socket::~Socket() { close(); }
 
 void Socket::connect(const std::string& h, int p) {
 	host = h;


### PR DESCRIPTION
- Also make CodecFactory a proper singleton so that dynamically allocated codecs are freed on exit
- Use a signed int to calculate the number of transports
- Now the valgrind tests pass
