### PR TITLE
HRCPP-64 Workaround the fact that the Java 6 compiler has trouble with inferring the return type of a generic

### DIFF
--- a/test/jniapi/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/test/jniapi/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -89,22 +89,24 @@ public class RemoteCacheImpl<K, V> implements RemoteCache<K, V> {
 
     @Override
     public boolean containsKey(K k) {
-        return relayedInvoker(new RelayedMethod() {
+        Boolean b = relayedInvoker(new RelayedMethod() {
             @Override
             public Object invoke(RelayBytes... rbs) {
                 return jniRemoteCache.containsKey(rbs[0]);
             }
         }, k);
+        return b;
     }
 
     @Override
     public boolean containsValue(V v) {
-        return relayedInvoker(new RelayedMethod() {
+        Boolean b = relayedInvoker(new RelayedMethod() {
             @Override
             public Object invoke(RelayBytes... rbs) {
                 return jniRemoteCache.containsValue(rbs[0]);
             }
         }, v);
+        return b;
     }
 
     @Override


### PR DESCRIPTION
HRCPP-64 Workaround the fact that the Java 6 compiler has trouble with inferring the return type of a generic method when unboxing is also needed

https://issues.jboss.org/browse/HRCPP-64
