### PR TITLE
HRCPP-70 Codec methods are not virtual

### DIFF
--- a/src/hotrod/impl/protocol/Codec.h
+++ b/src/hotrod/impl/protocol/Codec.h
@@ -4,12 +4,15 @@
 
 
 #include "infinispan/hotrod/types.h"
+#include <set>
+#include <map>
 
 namespace infinispan {
 namespace hotrod {
 
 namespace transport {
 class Transport;
+class InetSocketAddress;
 }
 
 namespace protocol {
@@ -26,6 +29,12 @@ class Codec
       transport::Transport& transport, HeaderParams& params) const = 0;
 
     virtual ~Codec() {}
+  protected:
+
+    virtual std::map<infinispan::hotrod::transport::InetSocketAddress, std::set<int32_t> > computeNewHashes(
+               infinispan::hotrod::transport::Transport& transport, uint32_t newTopologyId, int16_t numKeyOwners,
+               uint8_t hashFunctionVersion, uint32_t hashSpace, uint32_t clusterSize) const = 0;
+
 };
 
 }}} // namespace infinispan::hotrod::protocol

--- a/src/hotrod/impl/protocol/Codec10.h
+++ b/src/hotrod/impl/protocol/Codec10.h
@@ -5,16 +5,11 @@
 
 #include "hotrod/impl/protocol/Codec.h"
 
-#include <set>
-#include <map>
-
-
 namespace infinispan {
 namespace hotrod {
 
 namespace transport {
 class Transport;
-class InetSocketAddress;
 }
 
 namespace protocol {
@@ -37,6 +32,19 @@ class Codec10 : public Codec
         infinispan::hotrod::transport::Transport& transport,
         HeaderParams& params, uint8_t version) const;
 
+    std::map<infinispan::hotrod::transport::InetSocketAddress, std::set<int32_t> > computeNewHashes(
+        infinispan::hotrod::transport::Transport& transport, uint32_t newTopologyId, int16_t numKeyOwners,
+        uint8_t hashFunctionVersion, uint32_t hashSpace, uint32_t clusterSize) const;
+
+    // TODO : multithread management
+    static long msgId;
+
+    Codec10() {}
+
+  friend class CodecFactory;
+
+  private:
+
     void readNewTopologyIfPresent(
         infinispan::hotrod::transport::Transport& transport,
         HeaderParams& params) const;
@@ -48,18 +56,6 @@ class Codec10 : public Codec
     void checkForErrorsInResponseStatus(
         infinispan::hotrod::transport::Transport& transport,
         HeaderParams& params, uint8_t status) const;
-
-    std::map<infinispan::hotrod::transport::InetSocketAddress, std::set<int32_t> > computeNewHashes(
-        infinispan::hotrod::transport::Transport& transport, uint32_t newTopologyId, int16_t numKeyOwners,
-        uint8_t hashFunctionVersion, uint32_t hashSpace, uint32_t clusterSize) const;
-
-    // TODO : multithread management
-    static long msgId;
-
-  protected:
-    Codec10() {}
-
-  friend class CodecFactory;
 };
 
 }}} // namespace infinispan::hotrod::protocol

--- a/src/hotrod/impl/protocol/Codec11.h
+++ b/src/hotrod/impl/protocol/Codec11.h
@@ -17,6 +17,7 @@ public:
     HeaderParams& writeHeader(
                 infinispan::hotrod::transport::Transport& transport,
                 HeaderParams& params) const;
+protected:
 
     std::map<infinispan::hotrod::transport::InetSocketAddress, std::set<int32_t> > computeNewHashes(
             infinispan::hotrod::transport::Transport& transport, uint32_t newTopologyId, int16_t numKeyOwners,


### PR DESCRIPTION
Only computeNewHashes needs to be virtual as it is the only one being overridden. I have verified that proper computeNewHashes is indeed being invoked. Also constrained other codec helper methods to be private so we do not accidentally override some of them without first making them virtual (Thanks Radim). 
