### PR TITLE
HRCPP-79: Calling ConnectionPool::borrowObject holding TcpTansportFactor...

### DIFF
--- a/src/hotrod/impl/consistenthash/ConsistentHash.h
+++ b/src/hotrod/impl/consistenthash/ConsistentHash.h
@@ -20,7 +20,7 @@ public:
                     std::set<int32_t> > & servers2Hash, int32_t numKeyOwners,
             int32_t hashSpace) = 0;
 
-    virtual infinispan::hotrod::transport::InetSocketAddress getServer(const hrbytes& key) = 0;
+    virtual const infinispan::hotrod::transport::InetSocketAddress& getServer(const hrbytes& key) = 0;
 
     /**
      * Computes hash code of a given int32_t and then normalizes it to ensure a positive

--- a/src/hotrod/impl/consistenthash/ConsistentHashV1.cpp
+++ b/src/hotrod/impl/consistenthash/ConsistentHashV1.cpp
@@ -53,7 +53,7 @@ void ConsistentHashV1::init(
     this->numKeyOwners = nKeyOwners;
 }
 
-InetSocketAddress ConsistentHashV1::getServer(const hrbytes& key){
+const InetSocketAddress& ConsistentHashV1::getServer(const hrbytes& key){
     int32_t normalisedHashForKey;
     if (hashSpaceIsMaxInt) {
         normalisedHashForKey = getNormalizedHash(key);

--- a/src/hotrod/impl/consistenthash/ConsistentHashV1.h
+++ b/src/hotrod/impl/consistenthash/ConsistentHashV1.h
@@ -18,7 +18,7 @@ public:
                     std::set<int32_t> > & servers2Hash, int32_t numKeyOwners,
             int32_t hashSpace);
 
-    infinispan::hotrod::transport::InetSocketAddress getServer(const hrbytes& key);
+    const infinispan::hotrod::transport::InetSocketAddress& getServer(const hrbytes& key);
 
     int32_t getNormalizedHash(int32_t objectId);
     int32_t getNormalizedHash(const hrbytes& key);


### PR DESCRIPTION
HRCPP-79: Calling ConnectionPool::borrowObject holding TcpTansportFactory::lock causes deadlock
