### PR TITLE
HRCPP-76 ConsistentHashV1::positions is not cleared when updating hash

### DIFF
--- a/src/hotrod/impl/consistenthash/ConsistentHashV1.cpp
+++ b/src/hotrod/impl/consistenthash/ConsistentHashV1.cpp
@@ -18,6 +18,7 @@ void ConsistentHashV1::init(
         std::map<InetSocketAddress, std::set<int32_t> > & servers2Hash, int32_t nKeyOwners,
         int32_t hSpace) {
 
+    positions.clear();
     for (std::map<InetSocketAddress, std::set<int32_t> >::iterator outer_it =
             servers2Hash.begin(); outer_it != servers2Hash.end(); ++outer_it) {
 


### PR DESCRIPTION
Clearing positions as we reuse the same instance of ConsistentHashV1. All other fields are reinitialized in ConsistentHashV1::init
