### PR TITLE
HRCPP-77 TcpTransport should store serverAddress as value

### DIFF
--- a/src/hotrod/impl/transport/tcp/TcpTransport.cpp
+++ b/src/hotrod/impl/transport/tcp/TcpTransport.cpp
@@ -16,7 +16,8 @@ namespace transport {
 
 TcpTransport::TcpTransport(
     const InetSocketAddress& a, TransportFactory& factory)
-: AbstractTransport(factory), socket(), /*inStr(*socket),*/ invalid(false), serverAddress(a) {
+: AbstractTransport(factory), socket(), /*inStr(*socket),*/ invalid(false){
+    serverAddress = new InetSocketAddress(a.getAddress(), a.getPort());
     socket.connect(a.getAddress(),a.getPort(), factory.getConnectTimeout());
     socket.setTimeout(factory.getSoTimeout());
     socket.setTcpNoDelay(factory.isTcpNoDelay());
@@ -129,6 +130,7 @@ void TcpTransport::invalidate() {
 
 void TcpTransport::destroy() {
     socket.close();
+    delete serverAddress;
 }
 
 bool TcpTransport::isValid(){
@@ -136,7 +138,7 @@ bool TcpTransport::isValid(){
 }
 
 const InetSocketAddress& TcpTransport::getServerAddress() {
-   return serverAddress;
+   return *serverAddress;
 }
 
 }}} /* namespace */

--- a/src/hotrod/impl/transport/tcp/TcpTransport.h
+++ b/src/hotrod/impl/transport/tcp/TcpTransport.h
@@ -43,7 +43,7 @@ class TcpTransport : public AbstractTransport
     TcpTransport();
     Socket socket;
     bool invalid;
-    const InetSocketAddress& serverAddress;
+    InetSocketAddress* serverAddress;
 
     bool isValid();
 


### PR DESCRIPTION
This solution uses a pointer to create a fresh InetSocketAddress object and releases it when TcpTransport::destroy is called. If there is a better solution - please suggest.
