### PR TITLE
HRCPP-98 Add more methods to the SWIG layer

### DIFF
--- a/test/JniTest.java
+++ b/test/JniTest.java
@@ -1,202 +1,29 @@
-import org.infinispan.client.hotrod.RemoteCacheManager;
-import org.infinispan.client.hotrod.RemoteCache;
-import org.infinispan.client.hotrod.TestHelper;
-import org.infinispan.api.BasicCache;
-import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
-import org.infinispan.commons.util.ReflectionUtil;
-import org.infinispan.commons.util.Util;
-import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.server.hotrod.HotRodServer;
-import org.infinispan.test.SingleCacheManagerTest;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.Test;
+import org.testng.reporters.TextReporter;
+import org.testng.TestNG;
 import org.infinispan.client.hotrod.BulkGetKeysSimpleTest;
 import org.infinispan.client.hotrod.BulkGetSimpleTest;
 import org.infinispan.client.hotrod.CacheContainerTest;
+import org.infinispan.client.hotrod.DefaultExpirationTest;
 import org.infinispan.client.hotrod.ForceReturnValueTest;
 import org.infinispan.client.hotrod.HotRodIntegrationTest;
+import org.infinispan.client.hotrod.HotRodStatisticsTest;
 
-import java.lang.reflect.Method;
-
-import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.infinispan.test.TestingUtil.*;
-import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.*;
 
 public class JniTest {
-
-    private static final String CACHE_NAME = "someName";
-    protected static EmbeddedCacheManager cacheManager = null;
-    protected static HotRodServer hotrodServer = null;
-    protected static RemoteCacheManager remCacheManager = null;
-
-    private static void invokeMethod(Object obj, String name) {
-        Method method = ReflectionUtil.findMethod(obj.getClass(), name);
-        ReflectionUtil.invokeAccessibly(obj, method, null);
-    }
-
     public static void main(String[] args) {
-        boolean usingJNI = false;
-        System.out.println("at work");
+        TestNG testng = new TestNG();
+        TextReporter tr = new TextReporter("SWIG Tests", 2);
+        testng.setTestClasses(new Class[] { DefaultExpirationTest.class, HotRodIntegrationTest.class, ForceReturnValueTest.class, BulkGetSimpleTest.class, BulkGetKeysSimpleTest.class, HotRodStatisticsTest.class });
+        testng.addListener(tr);
+        testng.run();
+        /*
+         * We expect two failures:
+         *  ForceReturnValueTest.testRemoveNonExistForceReturnPrevious
+         *  HotRodIntegrationTest.testReplaceWithVersionWithLifespanAsync
+         */
 
-        HotRodIntegrationTest hotRodIntegrationTest = null;
-        CacheContainerTest cacheContainerTest = null;
-        ForceReturnValueTest forceReturnValueTest = null;
-        BulkGetKeysSimpleTest bulkGetKeysSimpleTest = null;
-        BulkGetSimpleTest bulkGetSimpleTest = null;
 
-        try {
-            System.out.println("Java + JNI Hot Rod Client");
-
-            //first test, the cache container test
-            System.out.println("=== Cache container test ====");
-            cacheContainerTest = new CacheContainerTest();
-            //invoking cacheContainerTest.createCacheManager();
-            invokeMethod(cacheContainerTest, "createCacheManager");
-
-            //cacheContainerTest.testObtainingSameInstanceMultipleTimes();
-            //cacheContainerTest.testObtainingSameInstanceMultipleTimes2();
-            cacheContainerTest.release();
-            System.out.println("=== Cache container test ==== PASSED");
-
-            System.out.println("=== Hot Rod integration test ====");
-
-            hotRodIntegrationTest = new HotRodIntegrationTest();
-            Method hrIntcreateCacheManager = hotRodIntegrationTest.getClass().getSuperclass()
-                    .getDeclaredMethod("createCacheManager");
-            hrIntcreateCacheManager.setAccessible(true);
-            Method setup = hotRodIntegrationTest.getClass().getSuperclass().getDeclaredMethod("setup");
-            setup.setAccessible(true);
-            //invoking methods in the right order
-            //hrIntcreateCacheManager.invoke(hotRodIntegrationTest);
-            setup.invoke(hotRodIntegrationTest);
-            System.out.println("=== Hot Rod integration test - test contains ====");
-            hotRodIntegrationTest.testContains();
-            System.out.println("=== Hot Rod integration test - test contains PASSED ====");
-            System.out.println("=== Hot Rod integration test - test Put ====");
-            hotRodIntegrationTest.testPut();
-            System.out.println("=== Hot Rod integration test - test Put PASSED ====");
-            System.out.println("=== Hot Rod integration test - test Remove ====");
-            hotRodIntegrationTest.testRemove();
-            System.out.println("=== Hot Rod integration test - test Remove PASSED ====");
-            System.out.println("=== Hot Rod integration test - test Replace ====");
-            hotRodIntegrationTest.testReplace();
-            System.out.println("=== Hot Rod integration test - test Replace PASSED ====");
-            System.out.println("=== Hot Rod integration test - test PutIfAbsent ====");
-            hotRodIntegrationTest.testPutIfAbsent();
-            System.out.println("=== Hot Rod integration test - test PutIfAbsent PASSED ====");
-
-            System.out.println("=== Hot Rod integration test - test GetVersionedCacheEntry ====");
-            hotRodIntegrationTest.testDestroyRemoteCacheFactory();
-            setup.invoke(hotRodIntegrationTest);
-
-            hotRodIntegrationTest.testGetVersionedCacheEntry();
-            System.out.println("=== Hot Rod integration test - test GetVersionedCacheEntry PASSED ====");
-
-            System.out.println("=== Hot Rod integration test - test GetWithMetadata ====");
-            hotRodIntegrationTest.testDestroyRemoteCacheFactory();
-            setup.invoke(hotRodIntegrationTest);
-
-            hotRodIntegrationTest.testGetWithMetadata();
-            System.out.println("=== Hot Rod integration test - test GetWithMetadata PASSED ====");
-
-            //TODO: testClear need investigations, it fails in the same manner than java
-            //Exception in thread "main" java.lang.AssertionError
-            //at org.infinispan.client.hotrod.HotRodIntegrationTest.testClear(HotRodIntegrationTest.java:293)
-            //at Simple2.main(Simple2.java:80)
-            ///////////
-            /*
-             * System.out.println("=== Hot Rod integration test - test Clear ====");
-             * hotRodIntegrationTest.testClear();
-             * System.out.println("=== Hot Rod integration test - test Clear PASSED ====");
-             */
-
-            System.out.println("=== Hot Rod integration test ==== PASSED");
-
-            System.out.println("=== Force Return Value test ====");
-            forceReturnValueTest = new ForceReturnValueTest();
-            setup = forceReturnValueTest.getClass().getDeclaredMethod("setup");
-            setup.setAccessible(true);
-            setup.invoke(forceReturnValueTest);
-
-            System.out.println("=== Force Return Value test - test Put ====");
-            forceReturnValueTest.testPut();
-            System.out.println("=== Force Return Value test - test Put PASSED ====");
-
-            System.out.println("=== Force Return Value test - test Remove ====");
-            forceReturnValueTest.testRemove();
-            System.out.println("=== Force Return Value test - test Remove PASSED ====");
-
-            //TODO: this fails with invalid magic number in response
-            // System.out.println("=== Force Return Value test - test RemoveNonExistForceReturnPrevious ====");
-            // forceReturnValueTest.testRemoveNonExistForceReturnPrevious();
-            // System.out.println("=== Force Return Value test - test RemoveNonExistForceReturnPrevious PASSED ====");
-
-            System.out.println("=== Force Return Value test - test Contains ====");
-            forceReturnValueTest.testContains();
-            System.out.println("=== Force Return Value test - test Contains PASSED ====");
-
-            System.out.println("=== Force Return Value test - test Replace ====");
-            forceReturnValueTest.testReplace();
-            System.out.println("=== Force Return Value test - test Replace PASSED ====");
-
-            System.out.println("=== Force Return Value test - test PutIfAbsent ====");
-            forceReturnValueTest.testPutIfAbsent();
-            System.out.println("=== Force Return Value test - test PutIfAbsent PASSED ====");
-
-            System.out.println("=== Force Return Value test ==== PASSED");
-
-            System.out.println("=== Bulk Get Simple test ====");
-            bulkGetSimpleTest = new BulkGetSimpleTest();
-            invokeMethod(bulkGetSimpleTest, "createCacheManagers");
-
-            System.out.println("=== Bulk Get Simple test - test Get Bulk ====");
-            bulkGetSimpleTest.testBulkGet();
-            System.out.println("=== Bulk Get Simple test - test Get Bulk PASSED ====");
-
-            System.out.println("=== Bulk Get Simple test - test Get Bulk With Size ====");
-            bulkGetSimpleTest.testBulkGetWithSize();
-            System.out.println("=== Bulk Get Simple test - test Get Bulk With Size PASSED ====");
-
-            System.out.println("=== Bulk Get Keys Simple test ====");
-            bulkGetKeysSimpleTest = new BulkGetKeysSimpleTest();
-            invokeMethod(bulkGetKeysSimpleTest, "createCacheManagers");
-            System.out.println("=== Bulk Get Simple test - test Get Bulk KeySet ====");
-            bulkGetKeysSimpleTest.testBulkGetKeys();
-            System.out.println("=== Bulk Get Simple test - test Get Bulk KeySet PASSED ====");
-
-            System.out.println("=== Bulk Get Simple test ==== PASSED");
-        } catch (Throwable e) {
-            System.out.println("Test Error");
-            e.printStackTrace();
+        if (testng.hasFailure() && tr.getFailedTests().size() > 2)
             System.exit(1);
-        } finally {
-            if (hotRodIntegrationTest != null) {
-                hotRodIntegrationTest.testDestroyRemoteCacheFactory();
-            }
-            if (cacheContainerTest != null) {
-                cacheContainerTest.release();
-            }
-            if (forceReturnValueTest != null) {
-                forceReturnValueTest.destroy();
-            }
-            if (bulkGetSimpleTest != null) {
-                try {
-                    invokeMethod(bulkGetSimpleTest, "destroy");
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
-                bulkGetSimpleTest.release();
-            }
-            if (bulkGetKeysSimpleTest != null) {
-                try {
-                    invokeMethod(bulkGetKeysSimpleTest, "destroy");
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
-                bulkGetKeysSimpleTest.release();
-            }
-        }
     }
 }

--- a/test/ivy.xml
+++ b/test/ivy.xml
@@ -1,17 +1,16 @@
 <ivy-module version="2.0" xmlns:m="http://ant.apache.org/ivy/maven">
     <info organisation="org.infinispan" module="ispn-cpp-client"/>
     <dependencies>
-        <!-- <dependency org="org.infinispan" name="infinispan-server-hotrod" rev="6.0.0.CR1"/> -->
         <dependency org="org.testng" name="testng" rev="6.8"/>
-        <dependency org="org.infinispan" name="infinispan-server-hotrod" rev="6.0.0.CR1">
+        <dependency org="org.infinispan" name="infinispan-server-hotrod" rev="6.0.0.Final">
              <artifact name="infinispan-server-hotrod" type="jar" m:classifier="tests" />
              <artifact name="infinispan-server-hotrod" type="jar"/>
         </dependency>
-        <dependency org="org.infinispan" name="infinispan-core" rev="6.0.0.CR1" >
+        <dependency org="org.infinispan" name="infinispan-core" rev="6.0.0.Final" >
             <artifact name="infinispan-core" type="jar" m:classifier="tests" />
             <artifact name="infinispan-core" type="jar" />
         </dependency>
-        <dependency org="org.infinispan" name="infinispan-client-hotrod" rev="6.0.0.CR1" >
+        <dependency org="org.infinispan" name="infinispan-client-hotrod" rev="6.0.0.Final" >
                 <artifact name="infinispan-client-hotrod" type="jar" m:classifier="tests" />
                 <artifact name="infinispan-client-hotrod" type="jar"/>
         </dependency>

--- a/test/jniapi/org/infinispan/client/hotrod/RemoteCache.java
+++ b/test/jniapi/org/infinispan/client/hotrod/RemoteCache.java
@@ -39,6 +39,8 @@ public interface RemoteCache<K, V> {
 
     V remove(K k);
 
+    boolean removeWithVersion(K key, long version);
+
     void clear();
 
     boolean containsKey(K k);
@@ -50,6 +52,12 @@ public interface RemoteCache<K, V> {
     V replace(K key, V value, long lifespan, TimeUnit unit);
 
     V replace(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit);
+
+    boolean replaceWithVersion(K key, V newValue, long version);
+
+    boolean replaceWithVersion(K key, V newValue, long version, int lifespanSeconds);
+
+    boolean replaceWithVersion(K key, V newValue, long version, int lifespanSeconds, int maxIdleTimeSeconds);
 
     VersionedValue<V> getVersioned(K k);
 
@@ -127,4 +135,6 @@ public interface RemoteCache<K, V> {
     Set<Entry<K, V>> entrySet();
 
     boolean remove(K key, V value);
+
+    ServerStatistics stats();
 }

--- a/test/swig/java.i
+++ b/test/swig/java.i
@@ -46,23 +46,8 @@
 #include <infinispan/hotrod/ScopedBuffer.h>
 #include <infinispan/hotrod/Marshaller.h>
 
-//ZZZ
 #include <iostream>
 %}
-
-//I want use java.util.Map, not obscure SWIG types
-//%typemap(jstype) std::map<std::string, std::string> "java.util.Map<String,String>"
-//%typemap(javain,pre="    MapType temp$javainput = $javaclassname.convertMap($javainput);",pgcppname="temp$javainput") std::map<std::string, std::string> "$javaclassname.getCPtr(temp$javainput)"
-//%typemap(javaout,pre="   MapType temp$javainput = $javaclassname.convertMap($javainput);",pgcppname="temp$javainput") std::map<std::string, std::string> "$javaclassname.getCPtr(temp$javainput)"
-//%typemap(javacode) std::map<std::string, std::string> %{
-//  static $javaclassname convertMap(java.util.Map<String,String> in) {
-//    $javaclassname out = new $javaclassname();
-//    for (java.util.Map.Entry<String, String> entry : in.entrySet()) {
-//      out.set(entry.getKey(), entry.getValue());      
-//    }
-//    return out;
-//  }    
-//%}
 
 %template(MapType) std::map<std::string, std::string>;
 
@@ -131,6 +116,7 @@ class RelayBytes {
 %template(MapReturn) std::map<HR_SHARED_PTR<RelayBytes>, HR_SHARED_PTR<RelayBytes> >;
 %template(SetReturn) std::set<HR_SHARED_PTR<RelayBytes> >;
 %template(VectorReturn) std::vector<HR_SHARED_PTR<RelayBytes> >;
+%template(StringVectorReturn) std::vector<std::string>;
 
 %inline %{
  bool isNull(HR_SHARED_PTR<RelayBytes> ptr) {
@@ -152,6 +138,13 @@ class RelayBytes {
      std::vector<HR_SHARED_PTR<RelayBytes> > result;
      for (std::set<HR_SHARED_PTR<RelayBytes> >::iterator it = set.begin(); it != set.end(); ++it)
          result.push_back(*it);
+     return result;
+ }
+ 
+ std::vector<std::string > keySet(std::map<std::string, std::string > map) {
+     std::vector<std::string > result;
+     for (std::map<std::string, std::string >::iterator it = map.begin(); it != map.end(); ++it)
+         result.push_back(it->first);
      return result;
  }
 %}

--- a/test/swig/swig.cmake
+++ b/test/swig/swig.cmake
@@ -91,7 +91,13 @@ foreach(loop_var ${CMAKE_CONFIGURATION_TYPES})
 	set(JAVA_LIBRARY_PATH "${JAVA_LIBRARY_PATH}${CLASSPATH_SEPARATOR}${loop_var}")
 endforeach(loop_var)
 
-add_test(swig ${JAVA_RUNTIME} -ea "-Djava.library.path=${JAVA_LIBRARY_PATH}" -cp "jni/hotrod-jni.jar${CLASSPATH_SEPARATOR}jni/lib/*${CLASSPATH_SEPARATOR}jni" JniTest)
+add_test(swig ${JAVA_RUNTIME} 
+    -ea 
+    "-Djava.library.path=${JAVA_LIBRARY_PATH}" 
+    -cp "jni/hotrod-jni.jar${CLASSPATH_SEPARATOR}jni/lib/*${CLASSPATH_SEPARATOR}jni"
+    #-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y  # For remote debugging 
+    JniTest
+)
 
 install (FILES "${CMAKE_CURRENT_BINARY_DIR}/jni/hotrod-jni.jar" DESTINATION jni)
 install (TARGETS hotrod-swig LIBRARY DESTINATION jni)


### PR DESCRIPTION
HRCPP-98 Add more methods to the SWIG layer
- ServerStatistics stats()
- boolean replaceWithVersion(K key, V newValue, long version);
- boolean replaceWithVersion(K key, V newValue, long version, int lifespanSeconds);
- boolean replaceWithVersion(K key, V newValue, long version, int lifespanSeconds, int maxIdleTimeSeconds);
- boolean removeWithVersion(K key, long version);

Make JniTest much simpler by using the TestNG APIs.
Test against 6.0.0.Final artifacts

https://issues.jboss.org/browse/HRCPP-98
