### PR TITLE
Add more test classes to JniTest

### DIFF
--- a/jni/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -5,6 +5,7 @@ package org.infinispan.client.hotrod;
 // originals
 import java.util.Properties;
 
+import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.jni.MapType;
 import org.infinispan.commons.marshall.Marshaller;
 // jni wrappers
@@ -14,8 +15,6 @@ public class RemoteCacheManager /* implements BasicCacheContainer */{
     private static final String ISPN_CLIENT_HOTROD_SERVER_LIST = "infinispan.client.hotrod.server_list";
 
     private org.infinispan.client.hotrod.jni.RemoteCacheManager jniRemoteCacheManager;
-    private org.infinispan.client.hotrod.jni.Configuration jniConfiguration;
-    private org.infinispan.client.hotrod.jni.ConfigurationBuilder jniConfigurationBuilder;
     private Marshaller marshaller;
 
     public RemoteCacheManager() {
@@ -31,6 +30,10 @@ public class RemoteCacheManager /* implements BasicCacheContainer */{
         this(String.format("%s:%d", server, port), true);
     }
 
+    public RemoteCacheManager(String server, int port, boolean start) {
+        this(String.format("%s:%d", server, port), start);
+    }
+
     public RemoteCacheManager(String servers, boolean start) {
         MapType converter = new MapType();
         converter.set(ISPN_CLIENT_HOTROD_SERVER_LIST, servers);
@@ -38,14 +41,19 @@ public class RemoteCacheManager /* implements BasicCacheContainer */{
         marshaller = new org.infinispan.commons.marshall.jboss.GenericJBossMarshaller();
     }
 
-    public RemoteCacheManager(Properties props) {
-
-        MapType converter = new MapType();
-        converter.set(ISPN_CLIENT_HOTROD_SERVER_LIST, (String) props.get(ISPN_CLIENT_HOTROD_SERVER_LIST));
-        jniRemoteCacheManager = new org.infinispan.client.hotrod.jni.RemoteCacheManager(converter, true);
-        marshaller = new org.infinispan.commons.marshall.jboss.GenericJBossMarshaller();
+    public RemoteCacheManager(Configuration config) {
+       this(config, true);
     }
 
+    public RemoteCacheManager(Configuration config, boolean start) {
+       jniRemoteCacheManager = new org.infinispan.client.hotrod.jni.RemoteCacheManager(config.getJniConfiguration(), start);
+       marshaller = new org.infinispan.commons.marshall.jboss.GenericJBossMarshaller();
+    }
+
+    public RemoteCacheManager(Properties props) {
+       this((String) props.get(ISPN_CLIENT_HOTROD_SERVER_LIST));
+    }
+    
     public <K, V> org.infinispan.client.hotrod.RemoteCache<K, V> getCache() {
         return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, "", false);
     }

--- a/jni/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
@@ -25,21 +25,11 @@ public class Configuration {
    private final ExecutorFactoryConfiguration asyncExecutorFactory;
    private final Class<? extends RequestBalancingStrategy> balancingStrategy;
    private final WeakReference<ClassLoader> classLoader;
-//   private final ConnectionPoolConfiguration connectionPool;
-//   private final int connectionTimeout;
    private final Class<? extends ConsistentHash>[] consistentHashImpl;
-//   private final boolean forceReturnValues;
-//   private final int keySizeEstimate;
    private final Class<? extends Marshaller> marshallerClass;
    private final Marshaller marshaller;
-//   private final boolean pingOnStartup;
-//   private final String protocolVersion;
    private final List<ServerConfiguration> servers;
-//   private final int socketTimeout;
-//   private final SslConfiguration ssl;
-//   private final boolean tcpNoDelay;
    private final Class<? extends TransportFactory> transportFactory;
-//   private final int valueSizeEstimate;
    
    private org.infinispan.client.hotrod.jni.Configuration jniConfiguration;
 
@@ -88,6 +78,10 @@ public class Configuration {
       this.marshaller = marshaller;
       this.servers = Collections.unmodifiableList(servers);
       this.transportFactory = transportFactory;
+   }
+
+   public org.infinispan.client.hotrod.jni.Configuration getJniConfiguration() {
+      return jniConfiguration;
    }
 
    public ExecutorFactoryConfiguration asyncExecutorFactory() {

--- a/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
+++ b/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
@@ -1,31 +1,56 @@
 package org.infinispan.client.jni.hotrod;
 
-import org.testng.reporters.TextReporter;
-import org.testng.TestNG;
+import org.infinispan.client.hotrod.BulkGetKeysDistTest;
+import org.infinispan.client.hotrod.BulkGetKeysReplTest;
 import org.infinispan.client.hotrod.BulkGetKeysSimpleTest;
+import org.infinispan.client.hotrod.BulkGetReplTest;
 import org.infinispan.client.hotrod.BulkGetSimpleTest;
-import org.infinispan.client.hotrod.CacheContainerTest;
 import org.infinispan.client.hotrod.DefaultExpirationTest;
 import org.infinispan.client.hotrod.ForceReturnValueTest;
+import org.infinispan.client.hotrod.ForceReturnValuesTest;
 import org.infinispan.client.hotrod.HotRodIntegrationTest;
+import org.infinispan.client.hotrod.HotRodServerStartStopTest;
 import org.infinispan.client.hotrod.HotRodStatisticsTest;
-
+import org.infinispan.client.hotrod.ServerErrorTest;
+import org.infinispan.client.hotrod.ServerShutdownTest;
+import org.infinispan.client.hotrod.SocketTimeoutErrorTest;
+import org.testng.TestNG;
+import org.testng.reporters.TextReporter;
 
 public class JniTest {
-    public static void main(String[] args) {
-        TestNG testng = new TestNG();
-        TextReporter tr = new TextReporter("SWIG Tests", 2);
-        testng.setTestClasses(new Class[] { DefaultExpirationTest.class, HotRodIntegrationTest.class, ForceReturnValueTest.class, BulkGetSimpleTest.class, BulkGetKeysSimpleTest.class, HotRodStatisticsTest.class });
-        testng.addListener(tr);
-        testng.run();
-        /*
-         * We expect two failures:
-         *  ForceReturnValueTest.testRemoveNonExistForceReturnPrevious
-         *  HotRodIntegrationTest.testReplaceWithVersionWithLifespanAsync
-         */
+   public static void main(String[] args) {
+      TestNG testng = new TestNG();
+      TextReporter tr = new TextReporter("SWIG Tests", 2);
 
+      testng.setTestClasses(new Class[] {
+            //Might work after HRCPP-103 is fixed
+            //                  BulkGetKeysDistTest.class,
+            //                  BulkGetKeysReplTest.class, 
+            //                  BulkGetReplTest.class, 
 
-        if (testng.hasFailure() && tr.getFailedTests().size() > 2)
-            System.exit(1);
-    }
+            //Known to work
+            BulkGetKeysSimpleTest.class, 
+            BulkGetSimpleTest.class, 
+            DefaultExpirationTest.class,
+            ForceReturnValueTest.class, 
+            ForceReturnValuesTest.class, 
+            HotRodIntegrationTest.class,
+            HotRodServerStartStopTest.class, 
+            HotRodStatisticsTest.class, 
+            ServerErrorTest.class,
+            ServerShutdownTest.class, 
+            SocketTimeoutErrorTest.class, 
+      });
+      testng.addListener(tr);
+      testng.run();
+      /*
+       * We expect one failure: HotRodIntegrationTest.testReplaceWithVersionWithLifespanAsync
+       */
+
+      String[] expectedTestFailures = { "HotRodIntegrationTest.testReplaceWithVersionWithLifespanAsync" };
+
+      if (testng.hasFailure() && tr.getFailedTests().size() > expectedTestFailures.length) {
+         System.exit(1);
+      }
+   }
 }


### PR DESCRIPTION
Also added a getter for the JNI configuration object in the
Configuration class, and reorganized the RemoteCacheManager
constructors.
