### PR TITLE
HRCPP-5: Updates to RemoteCacheManager and JniTest

### DIFF
--- a/jni/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -3,9 +3,13 @@
 package org.infinispan.client.hotrod;
 
 // originals
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URL;
 import java.util.Properties;
 
 import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.jni.MapType;
 import org.infinispan.commons.marshall.Marshaller;
 // jni wrappers
@@ -19,6 +23,11 @@ public class RemoteCacheManager /* implements BasicCacheContainer */{
 
     public RemoteCacheManager() {
         jniRemoteCacheManager = new org.infinispan.client.hotrod.jni.RemoteCacheManager();
+        marshaller = new org.infinispan.commons.marshall.jboss.GenericJBossMarshaller();
+    }
+
+    public RemoteCacheManager(boolean start) {
+        jniRemoteCacheManager = new org.infinispan.client.hotrod.jni.RemoteCacheManager(start);
         marshaller = new org.infinispan.commons.marshall.jboss.GenericJBossMarshaller();
     }
 
@@ -50,8 +59,20 @@ public class RemoteCacheManager /* implements BasicCacheContainer */{
        marshaller = new org.infinispan.commons.marshall.jboss.GenericJBossMarshaller();
     }
 
+    public RemoteCacheManager(URL config, boolean start) throws IOException {
+       Properties props = new Properties();
+       props.load(config.openStream());
+       new RemoteCacheManager(props, start);
+    }
+    
     public RemoteCacheManager(Properties props) {
-       this((String) props.get(ISPN_CLIENT_HOTROD_SERVER_LIST));
+       this(props, true);
+    }
+    
+    public RemoteCacheManager(Properties props, boolean start) {
+      jniRemoteCacheManager = new org.infinispan.client.hotrod.jni.RemoteCacheManager(new ConfigurationBuilder()
+            .withProperties(props).build().getJniConfiguration(), start);
+      marshaller = new org.infinispan.commons.marshall.jboss.GenericJBossMarshaller();
     }
     
     public <K, V> org.infinispan.client.hotrod.RemoteCache<K, V> getCache() {
@@ -76,6 +97,10 @@ public class RemoteCacheManager /* implements BasicCacheContainer */{
 
     public org.infinispan.client.hotrod.jni.RemoteCacheManager getJniManager() {
         return jniRemoteCacheManager;
+    }
+    
+    public boolean isStarted() {
+       return jniRemoteCacheManager.isStarted();
     }
     
     public void start() {

--- a/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
+++ b/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
@@ -5,13 +5,17 @@ import org.infinispan.client.hotrod.BulkGetKeysReplTest;
 import org.infinispan.client.hotrod.BulkGetKeysSimpleTest;
 import org.infinispan.client.hotrod.BulkGetReplTest;
 import org.infinispan.client.hotrod.BulkGetSimpleTest;
+import org.infinispan.client.hotrod.CacheManagerStoppedTest;
+import org.infinispan.client.hotrod.ClientAsymmetricClusterTest;
 import org.infinispan.client.hotrod.DefaultExpirationTest;
 import org.infinispan.client.hotrod.ForceReturnValueTest;
 import org.infinispan.client.hotrod.ForceReturnValuesTest;
 import org.infinispan.client.hotrod.HotRodIntegrationTest;
 import org.infinispan.client.hotrod.HotRodServerStartStopTest;
 import org.infinispan.client.hotrod.HotRodStatisticsTest;
+import org.infinispan.client.hotrod.RemoteCacheManagerTest;
 import org.infinispan.client.hotrod.ServerErrorTest;
+import org.infinispan.client.hotrod.ServerRestartTest;
 import org.infinispan.client.hotrod.ServerShutdownTest;
 import org.infinispan.client.hotrod.SocketTimeoutErrorTest;
 import org.testng.TestNG;
@@ -23,15 +27,21 @@ public class JniTest {
       TextReporter tr = new TextReporter("SWIG Tests", 2);
 
       testng.setTestClasses(new Class[] {
+            // "Failed to connect Operation now in progress"
+            //            RemoteCacheManagerTest.class,
+            //            ClientAsymmetricClusterTest.class,
+            //            ServerRestartTest.class,
+
             //Known to work
             BulkGetKeysDistTest.class,
             BulkGetKeysReplTest.class, 
-            BulkGetReplTest.class, 
             BulkGetKeysSimpleTest.class, 
+            BulkGetReplTest.class, 
             BulkGetSimpleTest.class, 
+            CacheManagerStoppedTest.class,
             DefaultExpirationTest.class,
-            ForceReturnValueTest.class, 
             ForceReturnValuesTest.class, 
+            ForceReturnValueTest.class, 
             HotRodIntegrationTest.class,
             HotRodServerStartStopTest.class, 
             HotRodStatisticsTest.class, 
@@ -41,11 +51,24 @@ public class JniTest {
       });
       testng.addListener(tr);
       testng.run();
-      /*
-       * We expect one failure: HotRodIntegrationTest.testReplaceWithVersionWithLifespanAsync
-       */
 
-      String[] expectedTestFailures = { "HotRodIntegrationTest.testReplaceWithVersionWithLifespanAsync" };
+      String[] expectedTestFailures = { 
+            // Async operations are not supported currently
+            "HotRodIntegrationTest.testReplaceWithVersionWithLifespanAsync",
+            // These CacheManagerStoppedTest throw the wrong exception from JNI
+            "CacheManagerStoppedTest.testGet",
+            "CacheManagerStoppedTest.testGetCacheOperations2",
+            "CacheManagerStoppedTest.testGetCacheOperations3",
+            "CacheManagerStoppedTest.testPut",
+            "CacheManagerStoppedTest.testPutAll",
+            "CacheManagerStoppedTest.testPutAllAsync",
+            "CacheManagerStoppedTest.testPutAsync",
+            "CacheManagerStoppedTest.testReplace",
+            "CacheManagerStoppedTest.testReplaceAsync",
+            "CacheManagerStoppedTest.testVersionedGet",
+            "CacheManagerStoppedTest.testVersionedRemove",
+            "CacheManagerStoppedTest.testVersionedRemoveAsync",
+      };
 
       if (testng.hasFailure() && tr.getFailedTests().size() > expectedTestFailures.length) {
          System.exit(1);


### PR DESCRIPTION
RemoteCacheManager:
   Added missing isStarted() method
   Modified constructor with properties to use a ConfigurationBuilder to
utilize all properties
   Added constructor with URL and boolean
   Added constructor with boolean

JniTest:
   Add CacheManagerStoppedTest
   Add three commented out tests that get the "Failed to connect
Operation now in progress" error
