### PR TITLE
Updates to RemoteCacheManager and JniTest

### DIFF
--- a/jni/src/main/java/org/infinispan/client/hotrod/exceptions/RemoteCacheManagerNotStartedException.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/exceptions/RemoteCacheManagerNotStartedException.java
@@ -1,0 +1,15 @@
+package org.infinispan.client.hotrod.exceptions;
+
+/**
+ * Thrown when trying to use an {@link org.infinispan.client.hotrod.RemoteCache} that is associated to an
+ * {@link org.infinispan.client.hotrod.RemoteCacheManager} that was not started. 
+ *
+ * @author Mircea.Markus@jboss.com
+ * @since 4.1
+ */
+public class RemoteCacheManagerNotStartedException extends HotRodClientException {
+
+   public RemoteCacheManagerNotStartedException(String message) {
+      super(message);
+   }
+}

--- a/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
+++ b/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
@@ -5,13 +5,17 @@ import org.infinispan.client.hotrod.BulkGetKeysReplTest;
 import org.infinispan.client.hotrod.BulkGetKeysSimpleTest;
 import org.infinispan.client.hotrod.BulkGetReplTest;
 import org.infinispan.client.hotrod.BulkGetSimpleTest;
+import org.infinispan.client.hotrod.CacheManagerStoppedTest;
+import org.infinispan.client.hotrod.ClientAsymmetricClusterTest;
 import org.infinispan.client.hotrod.DefaultExpirationTest;
 import org.infinispan.client.hotrod.ForceReturnValueTest;
 import org.infinispan.client.hotrod.ForceReturnValuesTest;
 import org.infinispan.client.hotrod.HotRodIntegrationTest;
 import org.infinispan.client.hotrod.HotRodServerStartStopTest;
 import org.infinispan.client.hotrod.HotRodStatisticsTest;
+import org.infinispan.client.hotrod.RemoteCacheManagerTest;
 import org.infinispan.client.hotrod.ServerErrorTest;
+import org.infinispan.client.hotrod.ServerRestartTest;
 import org.infinispan.client.hotrod.ServerShutdownTest;
 import org.infinispan.client.hotrod.SocketTimeoutErrorTest;
 import org.testng.TestNG;
@@ -23,15 +27,21 @@ public class JniTest {
       TextReporter tr = new TextReporter("SWIG Tests", 2);
 
       testng.setTestClasses(new Class[] {
+            // "Failed to connect Operation now in progress"
+            //            RemoteCacheManagerTest.class,
+            //            ClientAsymmetricClusterTest.class,
+            //            ServerRestartTest.class,
+
             //Known to work
             BulkGetKeysDistTest.class,
             BulkGetKeysReplTest.class, 
-            BulkGetReplTest.class, 
             BulkGetKeysSimpleTest.class, 
+            BulkGetReplTest.class, 
             BulkGetSimpleTest.class, 
+            CacheManagerStoppedTest.class,
             DefaultExpirationTest.class,
-            ForceReturnValueTest.class, 
             ForceReturnValuesTest.class, 
+            ForceReturnValueTest.class, 
             HotRodIntegrationTest.class,
             HotRodServerStartStopTest.class, 
             HotRodStatisticsTest.class, 
@@ -41,11 +51,24 @@ public class JniTest {
       });
       testng.addListener(tr);
       testng.run();
-      /*
-       * We expect one failure: HotRodIntegrationTest.testReplaceWithVersionWithLifespanAsync
-       */
 
-      String[] expectedTestFailures = { "HotRodIntegrationTest.testReplaceWithVersionWithLifespanAsync" };
+      String[] expectedTestFailures = { 
+            // Async operations are not supported currently
+            "HotRodIntegrationTest.testReplaceWithVersionWithLifespanAsync",
+            // These CacheManagerStoppedTest throw the wrong exception from JNI
+            "CacheManagerStoppedTest.testGet",
+            "CacheManagerStoppedTest.testGetCacheOperations2",
+            "CacheManagerStoppedTest.testGetCacheOperations3",
+            "CacheManagerStoppedTest.testPut",
+            "CacheManagerStoppedTest.testPutAll",
+            "CacheManagerStoppedTest.testPutAllAsync",
+            "CacheManagerStoppedTest.testPutAsync",
+            "CacheManagerStoppedTest.testReplace",
+            "CacheManagerStoppedTest.testReplaceAsync",
+            "CacheManagerStoppedTest.testVersionedGet",
+            "CacheManagerStoppedTest.testVersionedRemove",
+            "CacheManagerStoppedTest.testVersionedRemoveAsync",
+      };
 
       if (testng.hasFailure() && tr.getFailedTests().size() > expectedTestFailures.length) {
          System.exit(1);


### PR DESCRIPTION
RemoteCacheManager:
   Added missing isStarted() method
   Added constructor with URL and boolean
   Added constructor with boolean

JniTest:
   Add CacheManagerStoppedTest
   Add three commented out tests that get the "Failed to connect
Operation now in progress" error

Add RemoteCacheManagerNotStartedException to support
CacheManagerStoppedTest
