### PR TITLE
HRCPP-133: Modify retry handling in Socket::read

### DIFF
--- a/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
+++ b/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
@@ -61,8 +61,6 @@ public class JniTest {
             "CacheManagerStoppedTest.testPutAsync",
             "CacheManagerStoppedTest.testReplaceAsync",
             "CacheManagerStoppedTest.testVersionedRemoveAsync",
-            // Here until HRCPP-118 is resolved
-            "SocketTimeoutErrorTest.testErrorWhileDoingPut",
       };
 
       assertEquals(tr.getFailedTests().size(), expectedTestFailures.length);

--- a/src/hotrod/sys/posix/Socket.cpp
+++ b/src/hotrod/sys/posix/Socket.cpp
@@ -216,14 +216,15 @@ void Socket::setTimeout(int timeout) {
 }
 
 size_t Socket::read(char *p, size_t length) {
-    while(1) {
+    int retry = 10;
+    while(true) {
         ssize_t n =  recv(fd, p, length, 0);
-        if (n < 0 && errno != EAGAIN)
-            throwIOErr(host, port, "read", errno);
-        else if (n == 0)
-            throwIOErr(host, port, "no read", 0);
-        else
+        if (n > 0)
             return n;
+        else if ((errno == EAGAIN || errno == EINTR) && retry > 0)
+            retry--;
+        else if (n <= 0)
+            throwIOErr(host, port, "read", errno);
     }
 }
 

--- a/src/hotrod/sys/windows/Socket.cpp
+++ b/src/hotrod/sys/windows/Socket.cpp
@@ -198,14 +198,15 @@ void Socket::setTimeout(int timeout) {
 }
 
 size_t Socket::read(char *p, size_t length) {
-    while(1) {
+    int retry = 10;
+    while(true) {
         ssize_t n =  recv(fd, p, (int) length, 0);
-        if (n == SOCKET_ERROR)
-            throwIOErr(host, port, "read", WSAGetLastError());
-        else if (n == 0)
-            return 0;
-        else
+        if (n >= 0)
             return n;
+        else if ((n == WSATRY_AGAIN || n == WSAEINTR) && retry > 0)
+            retry--;
+        else
+            throwIOErr(host, port, "read", WSAGetLastError());
     }
 }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/HRCPP-133
- Retry the read 10\* times if the initial read sets errno to either
  EAGAIN or EINTR (WSATRY_AGAIN or WSAEINTR on Windows)
- Throw an exception if n is 0 or less than 0 and errno is different or
  all retries have happened
- Return 0 instead of throwing an exception, if appropriate
- Update the Windows version as well
