### PR TITLE
Minor bug fixes

### DIFF
--- a/jni/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -45,7 +45,7 @@ public class RemoteCacheManager /* implements BasicCacheContainer */{
     public RemoteCacheManager(String servers, boolean start) {
         MapType converter = new MapType();
         converter.set(ISPN_CLIENT_HOTROD_SERVER_LIST, servers);
-        jniRemoteCacheManager = new org.infinispan.client.hotrod.jni.RemoteCacheManager(converter, true);
+        jniRemoteCacheManager = new org.infinispan.client.hotrod.jni.RemoteCacheManager(converter, start);
         marshaller = new org.infinispan.commons.marshall.jboss.GenericJBossMarshaller();
     }
 
@@ -71,8 +71,8 @@ public class RemoteCacheManager /* implements BasicCacheContainer */{
     }
     
     public RemoteCacheManager(Properties props, boolean start) {
-      jniRemoteCacheManager = new org.infinispan.client.hotrod.jni.RemoteCacheManager(new ConfigurationBuilder()
-            .withProperties(props).build().getJniConfiguration(), start);
+      Configuration config = new ConfigurationBuilder().withProperties(props).build();
+      jniRemoteCacheManager = new org.infinispan.client.hotrod.jni.RemoteCacheManager(config.getJniConfiguration(), start);
       marshaller = new org.infinispan.commons.marshall.jboss.GenericJBossMarshaller();
     }
     

--- a/test/bin/server_ctl.py
+++ b/test/bin/server_ctl.py
@@ -78,7 +78,7 @@ def stop(verbose=False):
         os.unlink('servers.pkl')
     else:
         if verbose:
-            print 'no test servers in use'
+            print('no test servers in use')
     return 0
 
 def main():


### PR DESCRIPTION
Pass start parameter correctly in the RemoteCacheManager constructor
Use parentheses around a print command in server_ctl.py
