### PR TITLE
HRCPP-133 Reverting socket::read retry changes

### DIFF
--- a/jni/src/main/java/org/infinispan/client/hotrod/exceptions/HotRodClientException.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/exceptions/HotRodClientException.java
@@ -1,5 +1,7 @@
 package org.infinispan.client.hotrod.exceptions;
 
+import java.net.SocketTimeoutException;
+
 /**
  * Base class for exceptions reported by the hot rod client.
  *
@@ -15,6 +17,9 @@ public class HotRodClientException extends RuntimeException {
 
    public HotRodClientException(String message) {
       super(message);
+      if(message.startsWith("timeout")){
+         initCause(new SocketTimeoutException(message));
+      }
    }
 
    public HotRodClientException(Throwable cause) {

--- a/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
+++ b/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
@@ -20,7 +20,6 @@ import org.infinispan.client.hotrod.ServerErrorTest;
 import org.infinispan.client.hotrod.ServerRestartTest;
 import org.infinispan.client.hotrod.ServerShutdownTest;
 import org.infinispan.client.hotrod.SocketTimeoutErrorTest;
-import org.infinispan.client.hotrod.retry.ServerFailureRetryTest;
 import org.testng.TestNG;
 import org.testng.reporters.TextReporter;
 
@@ -30,9 +29,10 @@ public class JniTest {
       TextReporter tr = new TextReporter("SWIG Tests", 2);
 
       testng.setTestClasses(new Class[] {
+            //HRCPP-119
 //            RemoteCacheManagerTest.class,
+            //HRCPP-120
 //            ClientAsymmetricClusterTest.class,
-              ServerFailureRetryTest.class,
 
             //Known to work
             BulkGetKeysDistTest.class, 
@@ -51,6 +51,7 @@ public class JniTest {
             ServerRestartTest.class,
             ServerShutdownTest.class,
             SocketTimeoutErrorTest.class, 
+            
       });
 
       testng.addListener(tr);

--- a/src/hotrod/sys/posix/Socket.cpp
+++ b/src/hotrod/sys/posix/Socket.cpp
@@ -216,16 +216,16 @@ void Socket::setTimeout(int timeout) {
 }
 
 size_t Socket::read(char *p, size_t length) {
-    int retry = 10;
-    while(true) {
-        ssize_t n =  recv(fd, p, length, 0);
-        if (n > 0)
-            return n;
-        else if ((errno == EAGAIN || errno == EINTR) && retry > 0)
-            retry--;
-        else if (n <= 0)
-            throwIOErr(host, port, "read", errno);
-    }
+    ssize_t n =  recv(fd, p, length, 0);
+    if (n > 0)
+        return n;
+    else if (n == 0)
+        throwIOErr(host, port, "no read", 0);
+    if (errno == EAGAIN || errno == EWOULDBLOCK)
+        throwIOErr(host, port, "timeout", errno);
+    else
+        throwIOErr(host, port, "read", errno);
+    return n;
 }
 
 void Socket::write(const char *p, size_t length) {

--- a/src/hotrod/sys/windows/Socket.cpp
+++ b/src/hotrod/sys/windows/Socket.cpp
@@ -198,16 +198,13 @@ void Socket::setTimeout(int timeout) {
 }
 
 size_t Socket::read(char *p, size_t length) {
-    int retry = 10;
-    while(true) {
-        ssize_t n =  recv(fd, p, (int) length, 0);
-        if (n >= 0)
-            return n;
-        else if ((n == WSATRY_AGAIN || n == WSAEINTR) && retry > 0)
-            retry--;
-        else
-            throwIOErr(host, port, "read", WSAGetLastError());
-    }
+    ssize_t n = recv(fd, p, (int) length, 0);
+    if (n != SOCKET_ERROR)
+        return n;
+    else if (WSAGetLastError() == WSAETIMEDOUT)
+        throwIOErr(host, port, "timeout", 0);
+    else
+        throwIOErr(host, port, "read", WSAGetLastError());
 }
 
 void Socket::write(const char *p, size_t length) {


### PR DESCRIPTION
https://issues.jboss.org/browse/HRCPP-133

The retry is causing the socket timeout contract to fail. Verified on Windows and Linux
