### PR TITLE
HRCPP-138: Fix two Python script issues

### DIFF
--- a/test/bin/probe_port.py
+++ b/test/bin/probe_port.py
@@ -1,3 +1,4 @@
+import logging
 import socket
 import sys
 import time
@@ -19,8 +20,8 @@ def main():
             s.connect(destination)
             sys.stdout.write('succeded!\n')
             break
-        except socket.error as ex:
-            sys.stdout.write('failed with "%s". ' % ex)
+        except socket.error:
+            logging.exception('Socket connection failed')
 
             if cumulated_time < timeout:
                 sys.stdout.write('Retrying in %ds (%ds to timeout).\n' % (reattempt_delay, timeout - cumulated_time))

--- a/test/bin/server_ctl.py
+++ b/test/bin/server_ctl.py
@@ -3,6 +3,7 @@
 #        python server_ctl stop
 
 import os
+import platform
 import sys
 import string
 import subprocess
@@ -13,7 +14,7 @@ import pickle
 def static_java_args(java, jboss_home) :
     # No luck calling standalone.bat without hanging.
     # This is what the batch file does in the default case for 6.0.0.
-    return [java, '-XX:+TieredCompilation', '-XX:+UseCompressedOops',
+    cmd = [java, '-XX:+TieredCompilation', '-XX:+UseCompressedOops',
             '-Xms64M', '-Xmx512M', '-XX:MaxPermSize=256M', '-Djava.net.preferIPv4Stack=true',
             '-Djboss.modules.system.pkgs=org.jboss.byteman',
             '-Dorg.jboss.boot.log.file=' + jboss_home + '/standalone/log/server.log',
@@ -21,6 +22,10 @@ def static_java_args(java, jboss_home) :
             '-jar', jboss_home + '/jboss-modules.jar', '-mp', jboss_home + '/modules',
             '-jaxpmodule', 'javax.xml.jaxp-provider', 'org.jboss.as.standalone', 
             '-Djboss.home.dir=' + jboss_home]
+    # This option doesn't work on a 32-bit JVM
+    if platform.architecture(java)[0].find('32') != -1:
+        cmd.remove('-XX:+UseCompressedOops')
+    return cmd
 
 def start(args):
     stop(verbose=False)


### PR DESCRIPTION
Use the logging module in probe_port.py, and check for 32-bit JVM in
server_ctl.py.
