### PR TITLE
BZ1215130 Remove forbidden chars from swig file

### DIFF
--- a/jni/src/main/swig/java.i
+++ b/jni/src/main/swig/java.i
@@ -176,7 +176,7 @@ class RelayBytes {
 // our mechanism for RemoteCache<byte[], byte[]> from the java side
 %template(RemoteCache_jb_jb) infinispan::hotrod::RemoteCache<RelayBytes, RelayBytes>;
 
-# create a do-nothing marshaller works with the pre-marshalled data
+// create a do-nothing marshaller works with the pre-marshalled data
 
 %{
 using infinispan::hotrod::ScopedBuffer;


### PR DESCRIPTION
Hey!

Please take a look at proposed solution for https://bugzilla.redhat.com/show_bug.cgi?id=1215130

`#` char causes newer version of swig to fail (for example `3.0.5-4.fc21`).

Thanks!