### PR TITLE
HRCPP-193 HRCPP-191 Access violation when linking against hotrod-static on Windows + static tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
+set (STATIC_FLAGS "-DHOTROD_DECLARE_STATIC")
 if (MSVC)
    set (COMPILER_FLAGS "/DNOMINMAX /EHsc")
    set (WARNING_FLAGS "")
@@ -189,7 +190,7 @@ set_target_properties (hotrod PROPERTIES SOVERSION "1.0")
 
 # Build a static library
 add_library (hotrod-static STATIC ${library_sources})
-set_target_properties(hotrod-static PROPERTIES COMPILE_FLAGS "-DHOTROD_DECLARE_STATIC ${COMPILER_FLAGS} ${WARNING_FLAGS}")
+set_target_properties(hotrod-static PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS} ${STATIC_FLAGS}")
 
 # TESTS
 
@@ -198,10 +199,19 @@ set_property(TARGET simple PROPERTY INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_
 set_target_properties (simple PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS}")
 target_link_libraries (simple hotrod)
 
+add_executable (simple-static test/Simple.cpp)
+set_property(TARGET simple-static PROPERTY INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include")
+set_target_properties (simple-static PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS} ${STATIC_FLAGS}")
+target_link_libraries (simple-static hotrod-static ${platform_libs})
+
 if (ENABLE_INTERNAL_TESTING)
-    add_executable (unit_test test/Unit.cpp)
-    set_target_properties (unit_test PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS}")
-    target_link_libraries (unit_test hotrod)
+    add_executable (unittest test/Unit.cpp)
+    set_target_properties (unittest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS}")
+    target_link_libraries (unittest hotrod)
+
+    add_executable (unittest-static test/Unit.cpp)
+    set_target_properties (unittest-static PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS} ${STATIC_FLAGS}")
+    target_link_libraries (unittest-static hotrod-static ${platform_libs})
 endif (ENABLE_INTERNAL_TESTING)
 
 add_executable (itest test/InteractiveTest.cpp)
@@ -212,7 +222,8 @@ target_link_libraries (itest hotrod)
 include (CTest)
 
 if (ENABLE_INTERNAL_TESTING)
-    add_test (unit_test unit_test)
+    add_test (unittest unittest)
+    add_test (unittest-static unittest-static)
 endif (ENABLE_INTERNAL_TESTING)    
 
 find_package(Java)
@@ -235,6 +246,7 @@ else (NOT ((EXISTS "${HOTROD_JBOSS_HOME}/bin/standalone.sh") AND (EXISTS "${HOTR
     add_test (start_server ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/server_ctl.py start ${JAVA_RUNTIME} ${HOTROD_JBOSS_HOME} single)
     add_test (probe_port ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)
     add_test (simple simple)
+    add_test (simple-static simple-static)
     add_test (stop_server ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/server_ctl.py stop)
 endif (NOT ((EXISTS "${HOTROD_JBOSS_HOME}/bin/standalone.sh") AND (EXISTS "${HOTROD_JBOSS_HOME}/bin/standalone.bat")))
 

--- a/src/hotrod/sys/windows/Thread.cpp
+++ b/src/hotrod/sys/windows/Thread.cpp
@@ -72,7 +72,7 @@ private:
 namespace {
 
 
-#ifdef _DLL
+#ifndef HOTROD_DECLARE_STATIC
 class ScopedCriticalSection
 {
   public:
@@ -132,7 +132,7 @@ unsigned __stdcall runThreadPrivate(void* p)
     SetEvent (threadPrivate->hrThreadDone); // allow join()
     threadPrivate->keepAlive.reset();         // may run ThreadPrivate destructor
 
-#ifdef _DLL
+#ifndef HOTROD_DECLARE_STATIC
     {
         ScopedCriticalSection l(threadLock);
         if (--runningThreads == 0)
@@ -157,7 +157,7 @@ void ThreadPrivate::start(ThreadPrivate::shared_ptr& tp) {
     hrThreadDone = CreateEvent (NULL, TRUE, FALSE, NULL);
     HOTROD_WINDOWS_CHECK_CRT_NZ(hrThreadDone);
 
-#ifdef _DLL
+#ifndef HOTROD_DECLARE_STATIC
     {
         ScopedCriticalSection l(threadLock);
         if (terminating)
@@ -173,7 +173,7 @@ void ThreadPrivate::start(ThreadPrivate::shared_ptr& tp) {
                                   0,
                                   &threadId);
 
-#ifdef _DLL
+#ifndef HOTROD_DECLARE_STATIC
     if (h == NULL) {
         ScopedCriticalSection l(threadLock);
         if (--runningThreads == 0)
@@ -262,7 +262,7 @@ void Thread::sleep(long millis) {
 }}}  // namespace
 
 
-#ifdef _DLL
+#ifndef HOTROD_DECLARE_STATIC
 
 namespace infinispan {
 namespace hotrod {


### PR DESCRIPTION
https://issues.jboss.org/browse/HRCPP-191
https://issues.jboss.org/browse/HRCPP-193

CMake passes /MD (release) and /MDd (debug) to the compiler even when the static library is built. Because of this _DLL is defined and the code in Thread.cpp specific to dlls is included but the DllMain() function which is supposed to take care of mem initialization is not called and this causes access violation errors to occur.

A "proper" fix would have been to pass /MT for release and /MTd [1] for debug instead of /MD and /MDd but it's not possible to set per target compiler flags (CMAKE_CXX_FLAGS_{DEBUG,RELEASE,..}) and setting the flags in COMPILE_FLAGS per target doesn't override the value generated by CMake as the custom flags are appended to the left of the CMake ones [3].

[1] https://msdn.microsoft.com/en-us/library/2kzt1wy3.aspx
[2] http://www.cmake.org/Wiki/CMake_Useful_Variables#Compilers_and_Tools
This PR uses the custom HOTROD_DECLARE_STATIC instead of _DLL.
[3] https://msdn.microsoft.com/en-us/library/wf06704c.aspx