### PR TITLE
HRCPP-195 BZ1228026 Message id should be threadsafe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,6 @@ set (internal_test_sources
 )
 endif (ENABLE_INTERNAL_TESTING)
 
-
 # Select driver
 if(HOTROD_WINAPI)
   set (platform_sources src/hotrod/sys/windows/Socket.cpp src/hotrod/sys/windows/Thread.cpp

--- a/src/hotrod/impl/protocol/Codec10.h
+++ b/src/hotrod/impl/protocol/Codec10.h
@@ -27,6 +27,8 @@ class Codec10 : public Codec
         infinispan::hotrod::transport::Transport& transport,
         HeaderParams& params) const;
 
+    long getMessageId();
+
   protected:
     HeaderParams& writeHeader(
         infinispan::hotrod::transport::Transport& transport,
@@ -35,9 +37,6 @@ class Codec10 : public Codec
     std::map<infinispan::hotrod::transport::InetSocketAddress, std::set<int32_t> > computeNewHashes(
         infinispan::hotrod::transport::Transport& transport, uint32_t newTopologyId, int16_t numKeyOwners,
         uint8_t hashFunctionVersion, uint32_t hashSpace, uint32_t clusterSize) const;
-
-    // TODO : multithread management
-    static long msgId;
 
     Codec10() {}
 

--- a/test/Unit.cpp
+++ b/test/Unit.cpp
@@ -1,4 +1,5 @@
 #include "infinispan/hotrod/ImportExport.h"
+#include <stdio.h>
 
 /* The tests using internal classes are compiled directly into the shared library/DLL,
    this binary just runs them */
@@ -13,8 +14,10 @@ HR_EXTERN bool murmurHash2StringTest();
 HR_EXTERN bool murmurHash3StringTest();
 HR_EXTERN bool murmurHash2IntTest();
 HR_EXTERN bool murmurHash3IntTest();
+HR_EXTERN void runConcurrentCodecWritesTest();
 
 int main(int, char**) {
+    runConcurrentCodecWritesTest();
     threadTest();
     syncTest();
     runOnceTest();


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/HRCPP-195
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1228026

Some concerns:
* Can we use C++ 2011 standard and `<atomic>`? It looks like both GCC and .NET support it [1].
* We should use GCC >= 4.7 with lock free atomic implementation [2]

[1] https://msdn.microsoft.com/en-us/library/hh874894.aspx
[2] http://stackoverflow.com/a/13138154/562699