### PR TITLE
HRCPP-197 C++ client failover does not work consistently

### DIFF
--- a/src/hotrod/impl/transport/tcp/ConnectionPool.cpp
+++ b/src/hotrod/impl/transport/tcp/ConnectionPool.cpp
@@ -68,12 +68,6 @@ void ConnectionPool::invalidateObject(const InetSocketAddress& key, TcpTransport
 		busyIt->second->remove(val);
 		// Destroy object
 		factory->destroyObject(key, *val);
-		// Add new transport to idle queue
-		std::map<InetSocketAddress, TransportQueuePtr>::iterator idleIt = idle.find(key);
-		if (idleIt == idle.end()) {
-			throw HotRodClientException("No idle queue for address!");
-		}
-		idleIt->second->push(&factory->makeObject(key));
     }
 }
 


### PR DESCRIPTION
Don't add the Transport to the idle queue in
ConnectionPool::invalidateObject. Creating the new Transport object in
the idle queue tries to connect to the socket which fails. This causes
operation retry and client failover issues.