### PR TITLE
Hrcpp 251/get cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ else(DEFINED HOTROD_PREBUILT_LIB_DIR)
       src/hotrod/impl/operations/BulkGetKeysOperation.cpp
       src/hotrod/impl/operations/StatsOperation.cpp
       src/hotrod/impl/operations/ClearOperation.cpp
+      src/hotrod/impl/operations/SizeOperation.cpp
       src/hotrod/impl/operations/FaultTolerantPingOperation.cpp
       src/hotrod/impl/operations/ExecuteCmdOperation.cpp
       src/hotrod/impl/protocol/HeaderParams.cpp

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ "$INFINISPAN_VERSION" == "" ]
+  then
+  echo Please define INFINISPAN_VERSION variable
+  exit 1
+fi
+
 BUILD_DIR=build
 
 wget -N http://downloads.jboss.org/infinispan/${INFINISPAN_VERSION}/infinispan-server-${INFINISPAN_VERSION}-bin.zip 

--- a/include/infinispan/hotrod/RemoteCache.h
+++ b/include/infinispan/hotrod/RemoteCache.h
@@ -638,15 +638,7 @@ template <class K, class V> class RemoteCache : private RemoteCacheBase
      *\return number of entries in cache
      */
     uint64_t size() {
-        portable::map<portable::string,portable::string> statistics;
-        base_stats(statistics);
-        const portable::pair<portable::string,portable::string> *p
-            = statistics.get("currentNumberOfEntries", portable::string::cmp);        
-        if (p) {
-            return strtoull(p->value.c_string(), 0, 10);            
-        } else {
-            return -1;
-        }
+    	return base_size();
     }
     /**
      *Returns true if and only if this cache has no entries.

--- a/include/infinispan/hotrod/RemoteCache.h
+++ b/include/infinispan/hotrod/RemoteCache.h
@@ -766,10 +766,6 @@ template <class K, class V> class RemoteCache : private RemoteCacheBase
     portable::counting_ptr<Marshaller<K> > keyMarshaller;
     portable::counting_ptr<Marshaller<V> > valueMarshaller;
 
-    // DEPRECATED: Library code must not use these fields
-    portable::counting_ptr<portable::counted_wrapper<std::shared_ptr<Marshaller<K> > > > keyMarshallerPtr;
-    portable::counting_ptr<portable::counted_wrapper<std::shared_ptr<Marshaller<V> > > > valueMarshallerPtr;
-
   friend class RemoteCacheManager;
 };
 

--- a/include/infinispan/hotrod/RemoteCacheBase.h
+++ b/include/infinispan/hotrod/RemoteCacheBase.h
@@ -45,6 +45,7 @@ protected:
     HR_EXTERN void  base_keySet(int scope, portable::vector<void*> &sbuf);
     HR_EXTERN void  base_stats(portable::map<portable::string,portable::string> &sbuf);
     HR_EXTERN void  base_clear();
+    HR_EXTERN uint64_t  base_size();
     HR_EXTERN void  base_withFlags(Flag flag);
     HR_EXTERN char *base_execute(RemoteCacheBase& remoteCacheBase, std::string cmdName,  const std::map<std::string,std::string>& args);
     HR_EXTERN CacheTopologyInfo base_getCacheTopologyInfo();

--- a/include/infinispan/hotrod/RemoteCacheManager.h
+++ b/include/infinispan/hotrod/RemoteCacheManager.h
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <map>
+#include <memory>
 
 namespace infinispan {
 namespace hotrod {
@@ -114,14 +115,21 @@ public:
      * \return the default RemoteCache to interact with on a remote Infinispan server
      *
      */
-    template <class K, class V> RemoteCache<K, V> getCache(
+    template <class K, class V> RemoteCache<K, V> &getCache(
         bool forceReturnValue = false)
     {
-        RemoteCache<K, V> rcache;
-        initCache(rcache, forceReturnValue);
-        rcache.keyMarshaller.reset(new BasicMarshaller<K>(), &Marshaller<K>::destroy);
-        rcache.valueMarshaller.reset(new BasicMarshaller<V>(), &Marshaller<V>::destroy);
-        return rcache;
+        const std::string key = forceReturnValue ? "/true" : "/false";
+        if (remoteCacheMap.find(key)==remoteCacheMap.end())
+        {
+          RemoteCache<K,V> *pRc= new RemoteCache<K,V>();
+          remoteCacheMap[key]= std::unique_ptr<RemoteCacheBase>(pRc);
+          RemoteCache<K, V> *rcache=(RemoteCache<K, V> *)remoteCacheMap[key].get();
+          initCache(*rcache, forceReturnValue);
+          rcache->keyMarshaller.reset(new BasicMarshaller<K>(), &Marshaller<K>::destroy);
+          rcache->valueMarshaller.reset(new BasicMarshaller<V>(), &Marshaller<V>::destroy);
+          return *rcache;
+        }
+        return *(RemoteCache<K, V> *)remoteCacheMap[key].get();
     }
 
     /**
@@ -139,14 +147,21 @@ public:
      * \return the RemoteCache to interact with on a remote Infinispan server
      *
      */
-    template <class K, class V> RemoteCache<K, V> getCache(
+    template <class K, class V> RemoteCache<K, V> &getCache(
         const std::string& name, bool forceReturnValue = false)
     {
-        RemoteCache<K, V> rcache;
-        initCache(rcache, name.c_str(), forceReturnValue);
-        rcache.keyMarshaller.reset(new BasicMarshaller<K>(), &Marshaller<K>::destroy);
-        rcache.valueMarshaller.reset(new BasicMarshaller<V>(), &Marshaller<V>::destroy);
-        return rcache;
+        const std::string key = forceReturnValue ? name+"/true" : name+"/false";
+        if (remoteCacheMap.find(key)==remoteCacheMap.end())
+        {
+          RemoteCache<K,V> *pRc= new RemoteCache<K,V>();
+          remoteCacheMap[key]= std::unique_ptr<RemoteCacheBase>(pRc);
+          RemoteCache<K, V> *rcache=(RemoteCache<K, V> *)remoteCacheMap[key].get();
+          initCache(*rcache, name.c_str(), forceReturnValue);
+          rcache->keyMarshaller.reset(new BasicMarshaller<K>(), &Marshaller<K>::destroy);
+          rcache->valueMarshaller.reset(new BasicMarshaller<V>(), &Marshaller<V>::destroy);
+          return *rcache;
+        }
+        return *(RemoteCache<K, V> *)remoteCacheMap[key].get();
     }
 
     /**
@@ -168,17 +183,27 @@ public:
      * \return the default RemoteCache to interact with on a remote Infinispan server
      *
      */
-    template <class K, class V> RemoteCache<K, V> getCache(
-        Marshaller<K> *km, void (*kd)(Marshaller<K> *),
-        Marshaller<V> *vm, void (*vd)(Marshaller<V> *),
-        bool forceReturnValue = false)
-    {
-        RemoteCache<K, V> rcache;
-        initCache(rcache, forceReturnValue);
-        rcache.keyMarshaller.reset(km, kd);
-        rcache.valueMarshaller.reset(vm, vd);
-        return rcache;
-    }
+	template<class K, class V> RemoteCache<K, V> &getCache(Marshaller<K> *km,
+			void (*kd)(Marshaller<K> *), Marshaller<V> *vm,
+			void (*vd)(Marshaller<V> *), bool forceReturnValue = false) {
+		const std::string key = forceReturnValue ? "/true" : "/false";
+		if (remoteCacheMap.find(key) == remoteCacheMap.end()) {
+			RemoteCache<K, V> *pRc = new RemoteCache<K, V>();
+			remoteCacheMap[key] = std::unique_ptr < RemoteCacheBase > (pRc);
+			RemoteCache<K, V> *rcache =
+					(RemoteCache<K, V> *) remoteCacheMap[key].get();
+			initCache(*rcache, forceReturnValue);
+			rcache->keyMarshaller.reset(km, kd);
+			rcache->valueMarshaller.reset(km, kd);
+			return *rcache;
+		}
+		RemoteCache<K, V> *rcache =
+				(RemoteCache<K, V> *) remoteCacheMap[key].get();
+		initCache(*rcache, forceReturnValue);
+		rcache->keyMarshaller.reset(km, kd);
+		rcache->valueMarshaller.reset(vm, vd);
+		return *rcache;
+	}
 
     /**
      * Returns RemoteCache for the given key and value marshallers, the cache name and an
@@ -200,47 +225,34 @@ public:
      * \return the RemoteCache to interact with on a remote Infinispan server
      *
      */
-    template <class K, class V> RemoteCache<K, V> getCache(
+    template <class K, class V> RemoteCache<K, V> &getCache(
         Marshaller<K> *km, void (*kd)(Marshaller<K> *),
         Marshaller<V> *vm, void (*vd)(Marshaller<V> *),
         const std::string& name, bool forceReturnValue = false)
     {
-        RemoteCache<K, V> rcache;
-        initCache(rcache, name.c_str(), forceReturnValue);
-        rcache.keyMarshaller.reset(km, kd);
-        rcache.valueMarshaller.reset(vm, vd);
-        return rcache;
+		const std::string key = forceReturnValue ? name+"/true" : name+"/false";
+		if (remoteCacheMap.find(key) == remoteCacheMap.end()) {
+			RemoteCache<K, V> *pRc = new RemoteCache<K, V>();
+			remoteCacheMap[key] = std::unique_ptr < RemoteCacheBase > (pRc);
+			RemoteCache<K, V> *rcache =
+					(RemoteCache<K, V> *) remoteCacheMap[key].get();
+			initCache(*rcache, name.c_str(), forceReturnValue);
+			rcache->keyMarshaller.reset(km, kd);
+			rcache->valueMarshaller.reset(km, kd);
+			return *rcache;
+		}
+		RemoteCache<K, V> *rcache =
+				(RemoteCache<K, V> *) remoteCacheMap[key].get();
+		initCache(*rcache, name.c_str(), forceReturnValue);
+		rcache->keyMarshaller.reset(km, kd);
+		rcache->valueMarshaller.reset(vm, vd);
+		return *rcache;
     }
 
-    // DEPRECATED
-    template <class K, class V> RemoteCache<K, V> getCache(
-        std::shared_ptr<Marshaller<K> > km, std::shared_ptr<Marshaller<V> > vm,
-        bool forceReturnValue = false)
-    {
-        RemoteCache<K, V> rcache;
-        initCache(rcache, forceReturnValue);
-        rcache.keyMarshallerPtr.reset(new portable::counted_wrapper<std::shared_ptr<Marshaller<K> > >(km), &genericDelete);
-        rcache.valueMarshallerPtr.reset(new portable::counted_wrapper<std::shared_ptr<Marshaller<V> > >(vm), &genericDelete);
-        rcache.keyMarshaller.reset(&*km, &genericNoDelete);
-        rcache.valueMarshaller.reset(&*vm, &genericNoDelete);
-        return rcache;
-    }
-
-    template <class K, class V> RemoteCache<K, V> getCache(
-        std::shared_ptr<Marshaller<K> > km, std::shared_ptr<Marshaller<V> > vm,
-        const std::string& name, bool forceReturnValue = false)
-    {
-        RemoteCache<K, V> rcache;
-        initCache(rcache, name.c_str(), forceReturnValue);
-        rcache.keyMarshallerPtr.reset(new portable::counted_wrapper<std::shared_ptr<Marshaller<K> > >(km), &genericDelete);
-        rcache.valueMarshallerPtr.reset(new portable::counted_wrapper<std::shared_ptr<Marshaller<V> > >(vm), &genericDelete);
-        rcache.keyMarshaller.reset(&*km, &genericNoDelete);
-        rcache.valueMarshaller.reset(&*vm, &genericNoDelete);
-        return rcache;
-    }
 
 private:
     void *impl;
+    std::map<std::string, std::unique_ptr<RemoteCacheBase> > remoteCacheMap;
 
     void init(const portable::map<portable::string, portable::string>& configuration, bool start);
 

--- a/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
+++ b/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
@@ -70,10 +70,11 @@ public class JniTest implements IMethodSelector {
             // omitting RoundRobin* tests
             ServerErrorTest.class,
             ServerRestartTest.class,
-            ServerShutdownTest.class,
+            SizeTest.class,
             SocketTimeoutErrorTest.class,
             SegmentOwnershipLocalTest.class,
-            SegmentOwnershipDistTest.class
+            SegmentOwnershipDistTest.class,
+            ServerShutdownTest.class
             // SslTest.class,                        // SSL not implemented
             // TransportObjectFactoryTest.class,     // omitting
       });
@@ -97,7 +98,8 @@ public class JniTest implements IMethodSelector {
             "HotRodIntegrationTest.testGetWithMetadata",
             "RemoteCacheManagerTest.testGetUndefinedCache",
             "ServerShutdownTest.testServerShutdownWithConnectedClient",
-            "ServerShutdownTest.testServerShutdownWithoutConnectedClient"
+            "ServerShutdownTest.testServerShutdownWithoutConnectedClient",
+            "SizeTest.testPersistentDistributedCacheSize"
       ));
       Set<String> expectedSkips = Collections.emptySet();
 

--- a/src/hotrod/api/RemoteCacheBase.cpp
+++ b/src/hotrod/api/RemoteCacheBase.cpp
@@ -104,6 +104,11 @@ void RemoteCacheBase::base_clear()
     IMPL->clear();
 }
 
+uint64_t RemoteCacheBase::base_size()
+{
+    return IMPL->size();
+}
+
 void RemoteCacheBase::base_ping() {
     IMPL->ping();
 }

--- a/src/hotrod/impl/RemoteCacheImpl.cpp
+++ b/src/hotrod/impl/RemoteCacheImpl.cpp
@@ -17,6 +17,7 @@
 #include "hotrod/impl/operations/BulkGetKeysOperation.h"
 #include "hotrod/impl/operations/StatsOperation.h"
 #include "hotrod/impl/operations/ClearOperation.h"
+#include "hotrod/impl/operations/SizeOperation.h"
 #include "hotrod/impl/operations/FaultTolerantPingOperation.h"
 #include "hotrod/impl/transport/TransportFactory.h"
 #include "hotrod/impl/protocol/CodecFactory.h"
@@ -173,9 +174,9 @@ void RemoteCacheImpl::getBulk(RemoteCacheBase& remoteCacheBase, portable::map<vo
     getBulk(remoteCacheBase, 0, map);
 }
 
-void RemoteCacheImpl::getBulk(RemoteCacheBase& remoteCacheBase, int size, portable::map<void*, void*> &map) {
+void RemoteCacheImpl::getBulk(RemoteCacheBase& remoteCacheBase, int isize, portable::map<void*, void*> &map) {
     assertRemoteCacheManagerIsStarted();
-    std::unique_ptr<BulkGetOperation> gco(operationsFactory->newBulkGetOperation(size));
+    std::unique_ptr<BulkGetOperation> gco(operationsFactory->newBulkGetOperation(isize));
     std::map<std::vector<char>,std::vector<char>> res = gco->execute();
     portable::map<void *, void *> tmpMap(res, KeyUnmarshallerFtor(remoteCacheBase), ValueUnmarshallerFtor(remoteCacheBase));
     map = tmpMap.move();
@@ -200,6 +201,12 @@ void RemoteCacheImpl::clear() {
     assertRemoteCacheManagerIsStarted();
     std::unique_ptr<ClearOperation> gco(operationsFactory->newClearOperation());
     gco->execute();
+}
+
+uint64_t RemoteCacheImpl::size() {
+    assertRemoteCacheManagerIsStarted();
+    std::unique_ptr<SizeOperation> szo(operationsFactory->newSizeOperation());
+    return szo->execute();
 }
 
 const char *RemoteCacheImpl::getName() const {

--- a/src/hotrod/impl/RemoteCacheImpl.h
+++ b/src/hotrod/impl/RemoteCacheImpl.h
@@ -35,6 +35,7 @@ public:
     void  keySet(RemoteCacheBase& rcb, int scope, portable::vector<void*> &result);
     void  stats(portable::map<portable::string,portable::string> &stats);
     void  clear();
+    uint64_t size();
     std::vector<char> execute(RemoteCacheBase& /*remoteCacheBase*/, std::vector<char> cmdName, const portable::map<std::vector<char>,std::vector<char>>& args);
 
     operations::PingResult ping();

--- a/src/hotrod/impl/operations/OperationsFactory.cpp
+++ b/src/hotrod/impl/operations/OperationsFactory.cpp
@@ -17,6 +17,7 @@
 #include "hotrod/impl/operations/BulkGetKeysOperation.h"
 #include "hotrod/impl/operations/StatsOperation.h"
 #include "hotrod/impl/operations/ClearOperation.h"
+#include "hotrod/impl/operations/SizeOperation.h"
 #include "hotrod/impl/operations/FaultTolerantPingOperation.h"
 #include "hotrod/impl/operations/ExecuteCmdOperation.h"
 #include "infinispan/hotrod/Flag.h"
@@ -132,6 +133,11 @@ StatsOperation* OperationsFactory::newStatsOperation() {
 
 ClearOperation* OperationsFactory::newClearOperation() {
     return new ClearOperation(
+        codec, transportFactory, cacheNameBytes, topologyId, getFlags());
+}
+
+SizeOperation* OperationsFactory::newSizeOperation() {
+    return new SizeOperation(
         codec, transportFactory, cacheNameBytes, topologyId, getFlags());
 }
 

--- a/src/hotrod/impl/operations/OperationsFactory.h
+++ b/src/hotrod/impl/operations/OperationsFactory.h
@@ -39,8 +39,10 @@ class BulkGetOperation;
 class BulkGetKeysOperation;
 class StatsOperation;
 class ClearOperation;
+class SizeOperation;
 class FaultTolerantPingOperation;
 class ExecuteCmdOperation;
+
 
 class OperationsFactory
 {
@@ -84,6 +86,8 @@ class OperationsFactory
     StatsOperation* newStatsOperation();
 
     ClearOperation* newClearOperation();
+
+    SizeOperation* newSizeOperation();
 
     ExecuteCmdOperation* newExecuteCmdOperation(
         const std::vector<char>& cmdName, const portable::map<std::vector<char>,std::vector<char>>& values);

--- a/src/hotrod/impl/operations/SizeOperation.cpp
+++ b/src/hotrod/impl/operations/SizeOperation.cpp
@@ -1,0 +1,35 @@
+#include "hotrod/impl/operations/SizeOperation.h"
+
+namespace infinispan {
+namespace hotrod {
+namespace operations {
+
+using namespace infinispan::hotrod::protocol;
+using namespace infinispan::hotrod::transport;
+
+SizeOperation::SizeOperation(
+    const Codec&      codec_,
+    std::shared_ptr<TransportFactory> transportFactory_,
+    const std::vector<char>&    cacheName_,
+    Topology&  topologyId_,
+    uint32_t    flags_)
+    : RetryOnFailureOperation<uint64_t>(
+        codec_, transportFactory_, cacheName_, topologyId_, flags_)
+{}
+
+Transport& SizeOperation::getTransport(int /*retryCount*/)
+{
+        return RetryOnFailureOperation<uint64_t>::transportFactory->getTransport(cacheName);
+}
+
+uint64_t SizeOperation::executeOperation(infinispan::hotrod::transport::Transport& transport)
+{
+    TRACE("Executing size(flags=%u)", flags);
+    std::unique_ptr<HeaderParams> params(&(RetryOnFailureOperation<uint64_t>::writeHeader(transport, SIZE_REQUEST)));
+    transport.flush();
+    RetryOnFailureOperation<uint64_t>::readHeaderAndValidate(transport, *params);
+    TRACE("Finished Size");
+    return transport.readVInt();
+}
+
+}}} /// namespace infinispan::hotrod::operations

--- a/src/hotrod/impl/operations/SizeOperation.h
+++ b/src/hotrod/impl/operations/SizeOperation.h
@@ -1,0 +1,37 @@
+#ifndef ISPN_HOTROD_OPERATIONS_SIZEOPERATION_H
+#define ISPN_HOTROD_OPERATIONS_SIZEOPERATION_H
+
+
+
+#include "hotrod/impl/operations/RetryOnFailureOperation.h"
+#include "hotrod/impl/transport/TransportFactory.h"
+#include "hotrod/impl/VersionedOperationResponse.h"
+#include "infinispan/hotrod/Flag.h"
+#include "hotrod/impl/protocol/HotRodConstants.h"
+
+namespace infinispan {
+namespace hotrod {
+class Topology;
+namespace operations {
+
+class SizeOperation : public RetryOnFailureOperation<uint64_t>
+{
+    protected:
+	SizeOperation(
+            const infinispan::hotrod::protocol::Codec&       codec_,
+            std::shared_ptr<transport::TransportFactory> transportFactory_,
+            const std::vector<char>&                                   cacheName_,
+            Topology&                                 topologyId_,
+            uint32_t                                   flags_);
+
+        infinispan::hotrod::transport::Transport& getTransport(int retryCount);
+
+        uint64_t executeOperation(infinispan::hotrod::transport::Transport& transport);
+
+    friend class OperationsFactory;
+};
+
+}}} // namespace infinispan::hotrod::operations
+
+#endif // ISPN_HOTROD_OPERATIONS_SIZEOPERATION_H
+

--- a/src/hotrod/impl/protocol/HeaderParams.cpp
+++ b/src/hotrod/impl/protocol/HeaderParams.cpp
@@ -66,6 +66,8 @@ uint8_t HeaderParams::toOpRespCode(uint8_t code) {
         return HotRodConstants::GET_WITH_VERSION_RESPONSE;
     case HotRodConstants::CLEAR_REQUEST:
         return HotRodConstants::CLEAR_RESPONSE;
+    case HotRodConstants::SIZE_REQUEST:
+        return HotRodConstants::SIZE_RESPONSE;
     case HotRodConstants::STATS_REQUEST:
         return HotRodConstants::STATS_RESPONSE;
     case HotRodConstants::PING_REQUEST:

--- a/test/Simple.cpp
+++ b/test/Simple.cpp
@@ -421,9 +421,49 @@ int basicTest(RemoteCacheManager &cacheManager, RemoteCache<K,V> &cache) {
 }
 
 int main(int argc, char** argv) {
-    // Call basic test for every marshaller and every codec
 
-    int result;
+    int result=0;
+	std::cout << "Tests for CacheManager" << std::endl;
+    {
+        ConfigurationBuilder builder;
+        builder.addServer().host(argc > 1 ? argv[1] : "127.0.0.1").port(argc > 2 ? atoi(argv[2]) : 11222).protocolVersion(Configuration::PROTOCOL_VERSION_24);
+//        builder.balancingStrategyProducer(transport::MyRoundRobinBalancingStrategy::newInstance);
+        builder.balancingStrategyProducer(nullptr);
+        RemoteCacheManager cacheManager(builder.build(), false);
+        RemoteCache<std::string, std::string> &cachef1 = cacheManager.getCache<std::string, std::string>(false);
+        RemoteCache<std::string, std::string> &cachet1 = cacheManager.getCache<std::string, std::string>(true);
+        RemoteCache<std::string, std::string> &cachenf1 = cacheManager.getCache<std::string, std::string>("namedCache",false);
+        RemoteCache<std::string, std::string> &cachent1 = cacheManager.getCache<std::string, std::string>("namedCache",true);
+
+        RemoteCache<std::string, std::string> &cachet2 = cacheManager.getCache<std::string, std::string>(true);
+        RemoteCache<std::string, std::string> &cachef2 = cacheManager.getCache<std::string, std::string>(false);
+        RemoteCache<std::string, std::string> &cachenf2 = cacheManager.getCache<std::string, std::string>("namedCache",false);
+        RemoteCache<std::string, std::string> &cachent2 = cacheManager.getCache<std::string, std::string>("namedCache",true);
+        if (&cachef1 != &cachef2)
+        {
+            std::cerr << "Got two different cache instances(false): " << &cachef1 << "   " << &cachef2 << std::endl;
+            result=1;
+        }
+        if (&cachet1 != &cachet2)
+        {
+            std::cerr << "Got two different cache instances(false): " << &cachet1 << "   " << &cachet2 << std::endl;
+            result=1;
+        }
+        if (&cachef1 != &cachef2)
+        {
+            std::cerr << "Got two different cache instances(false): " << &cachenf1 << "   " << &cachenf2 << std::endl;
+            result=1;
+        }
+        if (&cachef1 != &cachef2)
+        {
+            std::cerr << "Got two different cache instances(false): " << &cachent1 << "   " << &cachent2 << std::endl;
+            result=1;
+        }
+    }
+    if (result!=0)
+    	return result;
+    std::cout << "PASS: Tests for CacheManager" << std::endl;
+    // Call basic test for every marshaller and every codec
     std::cout << "Basic Test with BasicMarshaller" << std::endl;
     {
         ConfigurationBuilder builder;


### PR DESCRIPTION
RemoteCacheManager now returns the same instance of RemoteCache for the same request.
getCache called with marshaller specified, just update the marshaller if the cache already exists.

Added code to simple.cpp to test this feature natively, since the same java test can't be wrapped correctly in swig.

plus build.sh stops if INFINISPAN_VERSION variable is not defined