### PR TITLE
Skip test HotRodAsyncReplicationTest.testPutKeyValue that randomly fails

### DIFF
--- a/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
+++ b/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
@@ -24,7 +24,8 @@ public class JniTest implements IMethodSelector {
 	"CacheManagerStoppedTest.testPutAllAsync",
 	"CacheManagerStoppedTest.testPutAsync",
 	"CacheManagerStoppedTest.testReplaceAsync",
-	"CacheManagerStoppedTest.testVersionedRemoveAsync"};
+	"CacheManagerStoppedTest.testVersionedRemoveAsync",
+        "HotRodAsyncReplicationTest.testPutKeyValue"};
 	
    private final static HashSet<String> passOverTestSet = new HashSet<String>(Arrays.asList(passOverTestList));
 	


### PR DESCRIPTION
skip test due to randomic failure