### PR TITLE
HRCPP-275 javascript now uses the namedCache

### DIFF
--- a/test/QueryTest.cpp
+++ b/test/QueryTest.cpp
@@ -60,9 +60,9 @@ int main(int argc, char** argv) {
 
     auto *testkm = new BasicTypesProtoStreamMarshaller<int>();
     auto *testvm = new ProtoStreamMarshaller<sample_bank_account::User>();
-
     RemoteCache<int, sample_bank_account::User> testCache = cacheManager.getCache<int, sample_bank_account::User>(
     		testkm, &Marshaller<int>::destroy, testvm, &Marshaller<sample_bank_account::User>::destroy, "namedCache", false);
+    testCache.clear();
     sample_bank_account::User_Address a;
     sample_bank_account::User user1;
     user1.set_id(3);

--- a/test/Simple.cpp
+++ b/test/Simple.cpp
@@ -488,7 +488,7 @@ int main(int argc, char** argv) {
             // execute() operation needs explicit JBossMarshalling<string> format for argument values
             s.insert(std::pair<std::string, std::string>(argName,JBasicMarshaller<std::string>::addPreamble(argValue)));
             std::string script ("// mode=local,language=javascript\n "
-            "var cache = cacheManager.getCache();\n"
+            "var cache = cacheManager.getCache(\"namedCache\");\n"
             "cache.put(\"a\", \"abc\");\n"
             "cache.put(\"b\", \"b\");\n"
             "cache.get(\"a\");\n");
@@ -543,7 +543,7 @@ int main(int argc, char** argv) {
             // execute() operation needs explicit JBossMarshalling<string> format for argument values
             s.insert(std::pair<std::string, std::string>(argName,JBasicMarshaller<std::string>::addPreamble(argValue)));
             std::string script ("// mode=local,language=javascript\n "
-            "var cache = cacheManager.getCache();\n"
+            "var cache = cacheManager.getCache(\"namedCache\");\n"
             "cache.put(\"a\", \"abc\");\n"
             "cache.put(\"b\", \"b\");\n"
             "cache.get(\"a\");\n");


### PR DESCRIPTION
Since 9.0.0.Alpha2 server forbids the use of unnamed cache to js.