### PR TITLE
Hrcpp 309 - Restore ConfigurationChildBuilder class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,7 @@ endif(ENABLE_INTERNAL_TESTING)
       src/hotrod/api/exceptions.cpp
       src/hotrod/impl/configuration/Configuration.cpp
       src/hotrod/impl/configuration/ConnectionPoolConfiguration.cpp
+      src/hotrod/impl/configuration/ConfigurationChildBuilder.cpp
       src/hotrod/impl/RemoteCacheManagerImpl.cpp
       src/hotrod/impl/RemoteCacheImpl.cpp
       src/hotrod/impl/Topology.cpp

--- a/include/infinispan/hotrod/ConfigurationChildBuilder.h
+++ b/include/infinispan/hotrod/ConfigurationChildBuilder.h
@@ -1,0 +1,129 @@
+#ifndef ISPN_HOTROD_CONFIGURATION_CONFIGURATIONCHILDBUILDER_H
+#define ISPN_HOTROD_CONFIGURATION_CONFIGURATIONCHILDBUILDER_H
+
+
+
+#include <string>
+#include "infinispan/hotrod/ImportExport.h"
+#include "Configuration.h"
+
+namespace infinispan {
+namespace hotrod {
+
+class ConfigurationBuilder;
+class ConnectionPoolConfigurationBuilder;
+class ServerConfigurationBuilder;
+class SslConfigurationBuilder;
+
+class HR_EXTERN ConfigurationChildBuilder
+{
+  public:
+    ConfigurationChildBuilder(ConfigurationBuilder &builder): m_builder(&builder) {}
+
+	/**
+	 * Adds a new remote server
+	 *
+	 */
+    ServerConfigurationBuilder& addServer();
+
+    /**
+     * Adds a list of remote servers in the form: host1[:port][;host2[:port]]...
+     *
+     * \return ConfigurationBuilder for further configuration
+     */
+    ConfigurationBuilder& addServers(const std::string &servers);
+
+    /**
+     * Configures the connection pool
+     *
+     * \return ConfigurationBuilder for further configuration
+     */
+    ConnectionPoolConfigurationBuilder& connectionPool();
+
+    /**
+     * This property defines the maximum socket connect timeout before giving up connecting to the
+     * server.
+     *
+     * \return ConfigurationBuilder for further configuration
+     */
+    ConfigurationBuilder& connectionTimeout(int connectionTimeout);
+
+    /**
+     * Whether or not to implicitly FORCE_RETURN_VALUE for all calls.
+     *
+     * \return ConfigurationBuilder for further configuration
+     */
+    ConfigurationBuilder& forceReturnValues(bool forceReturnValues);
+
+    /**
+     * This hint allows sizing of byte buffers when serializing and deserializing
+     * keys, to minimize array resizing. It defaults to 64.
+     *
+     * \return ConfigurationBuilder for further configuration
+     */
+    ConfigurationBuilder& keySizeEstimate(int keySizeEstimate);
+
+    /**
+     * This property defines the protocol version that this client should use. Defaults to 1.2. Other
+     * valid values include 1.0 and 1.1.
+     *
+     * \return ConfigurationBuilder for further configuration
+     * \sa Configuration::PROTOCOL_VERSION_10
+     */
+    ConfigurationBuilder& protocolVersion(const std::string &protocolVersion);
+
+    /**
+     * This property defines the maximum socket read timeout in milliseconds before giving up waiting
+     * for bytes from the server. Defaults to 60000 (1 minute)
+     *
+     * \return ConfigurationBuilder for further configuration
+     */
+    ConfigurationBuilder& socketTimeout(int socketTimeout);
+
+    /**
+     * SSL Configuration
+     *
+     * \return SslConfigurationBuilder for further SSL configuration
+     */
+    SslConfigurationBuilder& ssl();
+
+    /**
+     * Affects TCP NODELAY on the TCP stack. Defaults to enabled.
+     *
+     * \return ConfigurationBuilder for further configuration
+     */
+    ConfigurationBuilder& tcpNoDelay(bool tcpNoDelay);
+
+    /**
+     * This hint allows sizing of byte buffers when serializing and deserializing values, to minimize
+     * array resizing. It defaults to 512.
+     *
+     * \return ConfigurationBuilder for further configuration
+     */
+    ConfigurationBuilder& valueSizeEstimate(int valueSizeEstimate);
+
+    /**
+     * Sets the maximum number of retries for each request. A valid value should be greater or equals than 0 (zero).
+     * Zero means no retry will made in case of a network failure. It defaults to 10.
+     *
+     *\return ConfigurationBuilder instance to be used for further configuration
+     */
+    ConfigurationBuilder& maxRetries(int maxRetries_);
+
+    /**
+     * Sets the balancer generator function
+     *
+     *\return ConfigurationBuilder instance to be used for further configuration
+     */
+    ConfigurationBuilder& balancingStrategyProducer(FailOverRequestBalancingStrategy::ProducerFn bsp);
+
+    Configuration build();
+
+private:
+    // in order to store this class in collections, operator= must work
+    ConfigurationBuilder *m_builder;
+};
+
+}} // namespace
+
+#endif // ISPN_HOTROD_CONFIGURATION_CONFIGURATIONCHILDBUILDER_H

--- a/include/infinispan/hotrod/ConnectionPoolConfigurationBuilder.h
+++ b/include/infinispan/hotrod/ConnectionPoolConfigurationBuilder.h
@@ -2,6 +2,7 @@
 #define CONNECTIONPOOLCONFIGURATIONBUILDER_H_
 
 #include "infinispan/hotrod/ImportExport.h"
+#include "ConfigurationChildBuilder.h"
 
 namespace infinispan {
 namespace hotrod {
@@ -12,9 +13,11 @@ namespace hotrod {
  *
  */
 class ConnectionPoolConfigurationBuilder
+  : public ConfigurationChildBuilder
 {
   public:
-    ConnectionPoolConfigurationBuilder():
+    ConnectionPoolConfigurationBuilder(ConfigurationBuilder &builder):
+        ConfigurationChildBuilder(builder),
         m_exhaustedAction(WAIT),
         m_lifo(true),
         m_maxActive(8),
@@ -28,6 +31,8 @@ class ConnectionPoolConfigurationBuilder
         m_testOnBorrow(false),
         m_testOnReturn(false),
         m_testWhileIdle(true) {}
+    virtual void validate() {}
+    virtual ~ConnectionPoolConfigurationBuilder() {}
 
     /**
        * Specifies what happens when asking for a connection from a server's pool, and that pool is
@@ -192,7 +197,7 @@ class ConnectionPoolConfigurationBuilder
         return *this;
     }
 
-    ConnectionPoolConfiguration create() {
+    virtual ConnectionPoolConfiguration create() {
         return ConnectionPoolConfiguration(
             m_exhaustedAction,
             m_lifo,
@@ -207,6 +212,11 @@ class ConnectionPoolConfigurationBuilder
             m_testOnBorrow,
             m_testOnReturn,
             m_testWhileIdle);
+    }
+    virtual ConnectionPoolConfigurationBuilder& read(ConnectionPoolConfiguration& configuration) {
+        // FIXME: implement
+        (void) configuration;
+        return *this;
     }
 
   private:

--- a/include/infinispan/hotrod/ServerConfigurationBuilder.h
+++ b/include/infinispan/hotrod/ServerConfigurationBuilder.h
@@ -11,6 +11,7 @@
 #include <string>
 #include "infinispan/hotrod/ImportExport.h"
 #include "ServerConfiguration.h"
+#include "ConfigurationChildBuilder.h"
 
 namespace infinispan {
 namespace hotrod {
@@ -22,11 +23,13 @@ namespace hotrod {
  *
  */
 class ServerConfigurationBuilder
+  : public ConfigurationChildBuilder
 {
   public:
-    ServerConfigurationBuilder() :
-    	m_host("localhost"), m_port(11222) {}
+    ServerConfigurationBuilder(ConfigurationBuilder& builder_):
+        ConfigurationChildBuilder(builder_), m_host("localhost"), m_port(11222) {}
 
+    virtual void validate() {};
 	/***
 	 * Specifies host of remote HotRod server
 	 *
@@ -55,7 +58,7 @@ class ServerConfigurationBuilder
 	 *
 	 * \return created ServerConfiguration instance
 	 */
-    ServerConfiguration create()
+    virtual ServerConfiguration create()
     {
         return ServerConfiguration(m_host, m_port);
     }
@@ -66,7 +69,7 @@ class ServerConfigurationBuilder
 	 *
 	 * \return ServerConfigurationBuilder for further configuration
 	 */
-    ServerConfigurationBuilder& read(ServerConfiguration& configuration)
+    virtual ServerConfigurationBuilder& read(ServerConfiguration& configuration)
     {
         m_host = configuration.getHostCString();
         m_port = configuration.getPort();

--- a/include/infinispan/hotrod/SslConfigurationBuilder.h
+++ b/include/infinispan/hotrod/SslConfigurationBuilder.h
@@ -2,28 +2,30 @@
 #define SSLCONFIGURATIONBUILDER_H_
 
 #include "infinispan/hotrod/ImportExport.h"
-
+#include "ConfigurationChildBuilder.h"
+ 
 
 namespace infinispan {
 namespace hotrod {
 
 
 class SslConfigurationBuilder
+  : public ConfigurationChildBuilder
 {
   public:
-    SslConfigurationBuilder():
+    SslConfigurationBuilder(ConfigurationBuilder &parent): ConfigurationChildBuilder(parent),
         m_enabled(false), m_serverCAPath(), m_serverCAFile(), m_clientCertificateFile() {}
     SslConfiguration create() {
         return SslConfiguration(m_enabled, m_serverCAPath, m_serverCAFile, m_clientCertificateFile);
     }
-    SslConfigurationBuilder& read(SslConfiguration& configuration) {
+    virtual SslConfigurationBuilder& read(SslConfiguration& configuration) {
         m_enabled = configuration.enabled();
         m_serverCAPath = configuration.serverCAPath();
         m_serverCAFile = configuration.serverCAFile();
         m_clientCertificateFile = configuration.clientCertificateFile();
         return *this;
     }
-    void validate() {};
+    virtual void validate() {};
     
     /***
      * Enables SSL support

--- a/jni/src/main/swig/java.i
+++ b/jni/src/main/swig/java.i
@@ -75,6 +75,7 @@ using namespace infinispan::hotrod;
 
 %include "infinispan/hotrod/InetSocketAddress.h"
 %include "infinispan/hotrod/FailOverRequestBalancingStrategy.h"
+%include "infinispan/hotrod/ConfigurationChildBuilder.h"
 %include "infinispan/hotrod/SslConfigurationBuilder.h"
 %include "infinispan/hotrod/ServerConfigurationBuilder.h"
 %include "infinispan/hotrod/ConnectionPoolConfigurationBuilder.h"
@@ -178,6 +179,8 @@ class RelayBytes {
 %template(StringVectorReturn) std::vector<std::string>;
 %template(IntegerVectorReturn) std::vector<int>;
 %template(InetSocketAddressvectorReturn) std::vector<infinispan::hotrod::transport::InetSocketAddress>;
+%ignore std::vector<infinispan::hotrod::ServerConfigurationBuilder>::vector(size_type);
+%ignore std::vector<infinispan::hotrod::ServerConfigurationBuilder>::resize; 
 %template(ServerConfigurationBuilderVector) std::vector<infinispan::hotrod::ServerConfigurationBuilder>;
 %template(ServerConfigurationVector) std::vector<infinispan::hotrod::ServerConfiguration>;
 %template(ServerConfigurationMap) std::map<std::string,std::vector<infinispan::hotrod::ServerConfiguration> >;

--- a/src/hotrod/impl/configuration/ConfigurationChildBuilder.cpp
+++ b/src/hotrod/impl/configuration/ConfigurationChildBuilder.cpp
@@ -1,0 +1,148 @@
+#include "infinispan/hotrod/ConfigurationChildBuilder.h"
+#include "infinispan/hotrod/ConfigurationBuilder.h"
+
+
+namespace infinispan {
+namespace hotrod {
+
+
+/**
+ * Adds a new remote server
+ *
+ */
+ServerConfigurationBuilder& ConfigurationChildBuilder::addServer()
+{
+	return m_builder->addServer();
+}
+
+/**
+ * Adds a list of remote servers in the form: host1[:port][;host2[:port]]...
+ *
+ * \return ConfigurationBuilder for further configuration
+ */
+ConfigurationBuilder& ConfigurationChildBuilder::addServers(const std::string &servers)
+{
+	return m_builder->addServers(servers);
+}
+/**
+ * Configures the connection pool
+ *
+ * \return ConfigurationBuilder for further configuration
+ */
+ConnectionPoolConfigurationBuilder& ConfigurationChildBuilder::connectionPool()
+{
+	return m_builder->connectionPool();
+}
+
+/**
+ * This property defines the maximum socket connect timeout before giving up connecting to the
+ * server.
+ *
+ * \return ConfigurationBuilder for further configuration
+ */
+ConfigurationBuilder& ConfigurationChildBuilder::connectionTimeout(int connectionTimeout)
+{
+	return m_builder->connectionTimeout(connectionTimeout);
+}
+
+/**
+ * Whether or not to implicitly FORCE_RETURN_VALUE for all calls.
+ *
+ * \return ConfigurationBuilder for further configuration
+ */
+ConfigurationBuilder& ConfigurationChildBuilder::forceReturnValues(bool forceReturnValues)
+{
+	return m_builder->forceReturnValues(forceReturnValues);
+}
+
+/**
+ * This hint allows sizing of byte buffers when serializing and deserializing
+ * keys, to minimize array resizing. It defaults to 64.
+ *
+ * \return ConfigurationBuilder for further configuration
+ */
+ConfigurationBuilder& ConfigurationChildBuilder::keySizeEstimate(int keySizeEstimate)
+{
+	return m_builder->keySizeEstimate(keySizeEstimate);
+}
+
+/**
+ * This property defines the protocol version that this client should use. Defaults to 1.2. Other
+ * valid values include 1.0 and 1.1.
+ *
+ * \return ConfigurationBuilder for further configuration
+ * \sa Configuration::PROTOCOL_VERSION_10
+ */
+ConfigurationBuilder& ConfigurationChildBuilder::protocolVersion(const std::string &protocolVersion)
+{
+	return m_builder->protocolVersion(protocolVersion);
+}
+
+/**
+ * This property defines the maximum socket read timeout in milliseconds before giving up waiting
+ * for bytes from the server. Defaults to 60000 (1 minute)
+ *
+ * \return ConfigurationBuilder for further configuration
+ */
+ConfigurationBuilder& ConfigurationChildBuilder::socketTimeout(int socketTimeout)
+{
+	return m_builder->socketTimeout(socketTimeout);
+}
+
+/**
+ * SSL Configuration
+ *
+ * \return SslConfigurationBuilder for further SSL configuration
+ */
+SslConfigurationBuilder& ConfigurationChildBuilder::ssl()
+{
+	return m_builder->ssl();
+}
+
+/**
+ * Affects TCP NODELAY on the TCP stack. Defaults to enabled.
+ *
+ * \return ConfigurationBuilder for further configuration
+ */
+ConfigurationBuilder& ConfigurationChildBuilder::tcpNoDelay(bool tcpNoDelay)
+{
+	return m_builder->tcpNoDelay(tcpNoDelay);
+}
+
+/**
+ * This hint allows sizing of byte buffers when serializing and deserializing values, to minimize
+ * array resizing. It defaults to 512.
+ *
+ * \return ConfigurationBuilder for further configuration
+ */
+ConfigurationBuilder& ConfigurationChildBuilder::valueSizeEstimate(int valueSizeEstimate)
+{
+	return m_builder->valueSizeEstimate(valueSizeEstimate);
+}
+
+/**
+ * Sets the maximum number of retries for each request. A valid value should be greater or equals than 0 (zero).
+ * Zero means no retry will made in case of a network failure. It defaults to 10.
+ *
+ *\return ConfigurationBuilder instance to be used for further configuration
+ */
+ConfigurationBuilder& ConfigurationChildBuilder::maxRetries(int maxRetries_)
+{
+	return m_builder->maxRetries(maxRetries_);
+}
+
+/**
+ * Sets the balancer generator function
+ *
+ *\return ConfigurationBuilder instance to be used for further configuration
+ */
+ConfigurationBuilder& ConfigurationChildBuilder::balancingStrategyProducer(FailOverRequestBalancingStrategy::ProducerFn bsp)
+{
+	return m_builder->balancingStrategyProducer(bsp);
+}
+
+Configuration ConfigurationChildBuilder::build()
+{
+	return m_builder->build();
+}
+}}


### PR DESCRIPTION
This reintroduce the ConfigurationChildBuilder class into the ConfigurationBuilder hierarchy. The removal of this class (#231) has introduced unwanted API changes.