### PR TITLE
HRCPP-315 # Pass failed servers to balancing

### DIFF
--- a/include/infinispan/hotrod/FailOverRequestBalancingStrategy.h
+++ b/include/infinispan/hotrod/FailOverRequestBalancingStrategy.h
@@ -3,6 +3,7 @@
 
 #include <infinispan/hotrod/InetSocketAddress.h>
 #include <vector>
+#include <set>
 
 namespace infinispan {
 namespace hotrod {
@@ -14,7 +15,7 @@ class FailOverRequestBalancingStrategy
   public:
     typedef FailOverRequestBalancingStrategy* (*ProducerFn)();
     virtual void setServers(const std::vector<transport::InetSocketAddress>& servers) = 0;
-    virtual const transport::InetSocketAddress& nextServer() = 0;
+    virtual const transport::InetSocketAddress& nextServer(const std::set<transport::InetSocketAddress>& failedServer) = 0;
 
     virtual ~FailOverRequestBalancingStrategy() {};
   private:

--- a/jni/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
@@ -29,6 +29,7 @@ public class Configuration {
    private final Class<? extends Marshaller> marshallerClass;
    private final Marshaller marshaller;
    private final List<ServerConfiguration> servers;
+   private final List<ServerConfiguration> failoverServers;
    private final Class<? extends TransportFactory> transportFactory;
    
    private org.infinispan.client.hotrod.jni.Configuration jniConfiguration;
@@ -43,12 +44,13 @@ public class Configuration {
       this.marshallerClass = null;
       this.marshaller = null;
       this.servers = null;
+      this.failoverServers = null;
       this.transportFactory = null;
    }
 
    Configuration(ExecutorFactoryConfiguration asyncExecutorFactory, Class<? extends RequestBalancingStrategy> balancingStrategy, ClassLoader classLoader,
          ConnectionPoolConfiguration connectionPool, int connectionTimeout, Class<? extends ConsistentHash>[] consistentHashImpl, boolean forceReturnValues, int keySizeEstimate, Class<? extends Marshaller> marshallerClass,
-         boolean pingOnStartup, String protocolVersion, List<ServerConfiguration> servers, int socketTimeout, SslConfiguration ssl, boolean tcpNoDelay,
+         boolean pingOnStartup, String protocolVersion, List<ServerConfiguration> servers, List<ServerConfiguration> failOverServers, int socketTimeout, SslConfiguration ssl, boolean tcpNoDelay,
          Class<? extends TransportFactory> transportFactory, int valueSizeEstimate, int maxRetries) {
       this.jniConfiguration = new org.infinispan.client.hotrod.jni.Configuration(protocolVersion, connectionPool.getJniConnectionPoolConfiguration(),
             connectionTimeout, forceReturnValues, keySizeEstimate,  null, socketTimeout, ssl.getJniSslConfiguration(), tcpNoDelay,
@@ -60,23 +62,7 @@ public class Configuration {
       this.marshallerClass = marshallerClass;
       this.marshaller = null;
       this.servers = Collections.unmodifiableList(servers);
-      this.transportFactory = transportFactory;
-   }
-
-   Configuration(ExecutorFactoryConfiguration asyncExecutorFactory, Class<? extends RequestBalancingStrategy> balancingStrategy, ClassLoader classLoader,
-         ConnectionPoolConfiguration connectionPool, int connectionTimeout, Class<? extends ConsistentHash>[] consistentHashImpl, boolean forceReturnValues, int keySizeEstimate, Marshaller marshaller,
-         boolean pingOnStartup, String protocolVersion, List<ServerConfiguration> servers, int socketTimeout, SslConfiguration ssl, boolean tcpNoDelay,
-         Class<? extends TransportFactory> transportFactory, int valueSizeEstimate, int maxRetries) {
-      this.jniConfiguration = new org.infinispan.client.hotrod.jni.Configuration(protocolVersion, connectionPool.getJniConnectionPoolConfiguration(),
-            connectionTimeout, forceReturnValues, keySizeEstimate, null, socketTimeout, ssl.getJniSslConfiguration(), tcpNoDelay,
-            valueSizeEstimate, maxRetries);
-      this.asyncExecutorFactory = asyncExecutorFactory;
-      this.balancingStrategy = balancingStrategy;
-      this.classLoader = new WeakReference<ClassLoader>(classLoader);
-      this.consistentHashImpl = consistentHashImpl;
-      this.marshallerClass = null;
-      this.marshaller = marshaller;
-      this.servers = Collections.unmodifiableList(servers);
+      this.failoverServers = Collections.unmodifiableList(failOverServers);
       this.transportFactory = transportFactory;
    }
 

--- a/src/hotrod/impl/operations/AbstractKeyOperation.h
+++ b/src/hotrod/impl/operations/AbstractKeyOperation.h
@@ -32,11 +32,11 @@ template<class T> class AbstractKeyOperation : public RetryOnFailureOperation<T>
             key(_key)
         {}
 
-    transport::Transport& getTransport(int retryCount) {
+    transport::Transport& getTransport(int retryCount, const std::set<transport::InetSocketAddress>& failedServers) {
         if (retryCount == 0) {
-            return this->transportFactory->getTransport(key, this->cacheName);
+            return this->transportFactory->getTransport(key, this->cacheName, failedServers);
         } else {
-            return this->transportFactory->getTransport(this->cacheName);
+            return this->transportFactory->getTransport(this->cacheName, failedServers);
         }
     }
 

--- a/src/hotrod/impl/operations/BulkGetKeysOperation.cpp
+++ b/src/hotrod/impl/operations/BulkGetKeysOperation.cpp
@@ -22,11 +22,6 @@ BulkGetKeysOperation::BulkGetKeysOperation(
         codec_, transportFactory_, cacheName_, topologyId_, flags_), scope(scope_)
 {}
 
-Transport& BulkGetKeysOperation::getTransport(int /*retryCount*/)
-{
-        return RetryOnFailureOperation<std::set<std::vector<char>> >::transportFactory->getTransport(cacheName);
-}
-
 std::set<std::vector<char>> BulkGetKeysOperation::executeOperation(Transport& transport)
 {
     TRACE("Execute BulkGetKeys(flags=%u,scope=%d)", flags, scope);

--- a/src/hotrod/impl/operations/BulkGetKeysOperation.h
+++ b/src/hotrod/impl/operations/BulkGetKeysOperation.h
@@ -27,8 +27,6 @@ class BulkGetKeysOperation : public RetryOnFailureOperation<std::set<std::vector
             uint32_t                                   flags_,
             int                                    entryCount_);
 
-        infinispan::hotrod::transport::Transport& getTransport(int retryCount);
-
         std::set<std::vector<char>> executeOperation(infinispan::hotrod::transport::Transport& transport);
     private:
         int scope;

--- a/src/hotrod/impl/operations/BulkGetOperation.cpp
+++ b/src/hotrod/impl/operations/BulkGetOperation.cpp
@@ -18,11 +18,6 @@ BulkGetOperation::BulkGetOperation(
         codec_, transportFactory_, cacheName_, topologyId_, flags_), entryCount(entryCount_)
 {}
 
-Transport& BulkGetOperation::getTransport(int /*retryCount*/)
-{
-        return RetryOnFailureOperation<std::map<std::vector<char>, std::vector<char>> >::transportFactory->getTransport(cacheName);
-}
-
 std::map<std::vector<char>,std::vector<char>> BulkGetOperation::executeOperation(infinispan::hotrod::transport::Transport& transport)
 {
     TRACE("Execute BulkGet(flags=%u, entryCount=%d)", flags, entryCount);

--- a/src/hotrod/impl/operations/BulkGetOperation.h
+++ b/src/hotrod/impl/operations/BulkGetOperation.h
@@ -27,8 +27,6 @@ class BulkGetOperation : public RetryOnFailureOperation<std::map<std::vector<cha
             uint32_t                                   flags_,
             int                                    entryCount_);
 
-        infinispan::hotrod::transport::Transport& getTransport(int retryCount);
-
         std::map<std::vector<char>,std::vector<char>> executeOperation(infinispan::hotrod::transport::Transport& transport);
     private:
         int entryCount;

--- a/src/hotrod/impl/operations/ClearOperation.cpp
+++ b/src/hotrod/impl/operations/ClearOperation.cpp
@@ -17,11 +17,6 @@ ClearOperation::ClearOperation(
         codec_, transportFactory_, cacheName_, topologyId_, flags_)
 {}
 
-Transport& ClearOperation::getTransport(int /*retryCount*/)
-{
-        return RetryOnFailureOperation<std::vector<char>>::transportFactory->getTransport(cacheName);
-}
-
 std::vector<char> ClearOperation::executeOperation(infinispan::hotrod::transport::Transport& transport)
 {
     TRACE("Executing Clear(flags=%u)", flags);

--- a/src/hotrod/impl/operations/ClearOperation.h
+++ b/src/hotrod/impl/operations/ClearOperation.h
@@ -24,8 +24,6 @@ class ClearOperation : public RetryOnFailureOperation<std::vector<char>>
             Topology&                                 topologyId_,
             uint32_t                                   flags_);
 
-        infinispan::hotrod::transport::Transport& getTransport(int retryCount);
-
         std::vector<char> executeOperation(infinispan::hotrod::transport::Transport& transport);
 
     friend class OperationsFactory;

--- a/src/hotrod/impl/operations/ExecuteCmdOperation.cpp
+++ b/src/hotrod/impl/operations/ExecuteCmdOperation.cpp
@@ -53,10 +53,4 @@ std::vector<char> ExecuteCmdOperation::sendExecuteOperation(
 
 }
 
-Transport& ExecuteCmdOperation::getTransport(int /*retryCount*/)
-{
-        return RetryOnFailureOperation<std::vector<char>>::transportFactory->getTransport(cacheName);
-}
-
-
 }}} /* namespace */

--- a/src/hotrod/impl/operations/ExecuteCmdOperation.h
+++ b/src/hotrod/impl/operations/ExecuteCmdOperation.h
@@ -16,7 +16,6 @@ namespace operations {
 class ExecuteCmdOperation : public RetryOnFailureOperation<std::vector<char> >
 {
 protected:
-    infinispan::hotrod::transport::Transport& getTransport(int retryCount);
     ExecuteCmdOperation(
             const infinispan::hotrod::protocol::Codec&       codec_,
             std::shared_ptr<transport::TransportFactory> transportFactory_,

--- a/src/hotrod/impl/operations/FaultTolerantPingOperation.cpp
+++ b/src/hotrod/impl/operations/FaultTolerantPingOperation.cpp
@@ -17,11 +17,6 @@ FaultTolerantPingOperation::FaultTolerantPingOperation(
         codec_, transportFactory_, cacheName_, topologyId_, flags_)
 {}
 
-Transport& FaultTolerantPingOperation::getTransport(int /*retryCount*/)
-{
-        return RetryOnFailureOperation<PingResult>::transportFactory->getTransport(cacheName);
-}
-
 PingResult FaultTolerantPingOperation::executeOperation(transport::Transport& transport)
 {
     PingOperation pingOp(codec, topologyId, transport, cacheName);

--- a/src/hotrod/impl/operations/FaultTolerantPingOperation.h
+++ b/src/hotrod/impl/operations/FaultTolerantPingOperation.h
@@ -24,8 +24,6 @@ class FaultTolerantPingOperation : public RetryOnFailureOperation<PingResult>
             Topology&                                 topologyId_,
             uint32_t                                   flags_);
 
-        transport::Transport& getTransport(int retryCount);
-
         PingResult executeOperation(transport::Transport& transport);
 
     friend class OperationsFactory;

--- a/src/hotrod/impl/operations/QueryOperation.h
+++ b/src/hotrod/impl/operations/QueryOperation.h
@@ -36,10 +36,6 @@ public:
 					_queryRequest) {}
 	virtual ~QueryOperation();
 
-	transport::Transport& getTransport(int /*retryCount*/) {
-			return this->transportFactory->getTransport(this->cacheName);
-	}
-
 	QueryResponse executeOperation(transport::Transport &t) {
         std::unique_ptr<protocol::HeaderParams> params(
             &(this->writeHeader(t, QUERY_REQUEST)));

--- a/src/hotrod/impl/operations/RetryOnFailureOperation.h
+++ b/src/hotrod/impl/operations/RetryOnFailureOperation.h
@@ -17,11 +17,12 @@ template<class T> class RetryOnFailureOperation : public HotRodOperation<T>
   public:
     T execute() {
         int retryCount = 0;
+        std::set<transport::InetSocketAddress> failedServers;
         while (shouldRetry(retryCount)) {
             transport::Transport* transport = NULL;
             try {
                 // Transport retrieval should be retried
-                transport = &getTransport(retryCount);
+                transport = &getTransport(retryCount, failedServers);
                 const T& result = executeOperation(*transport);
                 releaseTransport(transport);
                 return result;
@@ -30,6 +31,7 @@ template<class T> class RetryOnFailureOperation : public HotRodOperation<T>
                 // instance is no longer usable and should be destroyed
                 //std::cout << "Transport: " << ((transport::TcpTransport*)transport)->getServerAddress().getPort() << std::endl;
             	transport::InetSocketAddress isa(te.getHostCString(),te.getPort());
+            	failedServers.insert(isa);
                 transportFactory->invalidateTransport(isa, transport);
                 logErrorAndThrowExceptionIfNeeded(retryCount, te);
             } catch (const RemoteNodeSuspectException& rnse) {
@@ -57,7 +59,7 @@ template<class T> class RetryOnFailureOperation : public HotRodOperation<T>
        return retryCount <= transportFactory->getMaxRetries();
     }
 
-    void releaseTransport(transport::Transport* transport) {
+    virtual void releaseTransport(transport::Transport* transport) {
         if (transport) {
             transportFactory->releaseTransport(*transport);
         }
@@ -79,7 +81,11 @@ template<class T> class RetryOnFailureOperation : public HotRodOperation<T>
 		}
 	}
 
-    virtual transport::Transport& getTransport(int retryCount) = 0;
+    virtual transport::Transport& getTransport(int /*retryCount*/, const std::set<transport::InetSocketAddress>& failedServers)
+    {
+            return transportFactory->getTransport(this->cacheName, failedServers);
+    }
+
     virtual T executeOperation(transport::Transport& transport) = 0;
 
     virtual ~RetryOnFailureOperation() {}

--- a/src/hotrod/impl/operations/SizeOperation.cpp
+++ b/src/hotrod/impl/operations/SizeOperation.cpp
@@ -17,11 +17,6 @@ SizeOperation::SizeOperation(
         codec_, transportFactory_, cacheName_, topologyId_, flags_)
 {}
 
-Transport& SizeOperation::getTransport(int /*retryCount*/)
-{
-        return RetryOnFailureOperation<uint64_t>::transportFactory->getTransport(cacheName);
-}
-
 uint64_t SizeOperation::executeOperation(infinispan::hotrod::transport::Transport& transport)
 {
     TRACE("Executing size(flags=%u)", flags);

--- a/src/hotrod/impl/operations/SizeOperation.h
+++ b/src/hotrod/impl/operations/SizeOperation.h
@@ -24,8 +24,6 @@ class SizeOperation : public RetryOnFailureOperation<uint64_t>
             Topology&                                 topologyId_,
             uint32_t                                   flags_);
 
-        infinispan::hotrod::transport::Transport& getTransport(int retryCount);
-
         uint64_t executeOperation(infinispan::hotrod::transport::Transport& transport);
 
     friend class OperationsFactory;

--- a/src/hotrod/impl/operations/StatsOperation.cpp
+++ b/src/hotrod/impl/operations/StatsOperation.cpp
@@ -17,11 +17,6 @@ StatsOperation::StatsOperation(
         codec_, transportFactory_, cacheName_, topologyId_, flags_)
 {}
 
-Transport& StatsOperation::getTransport(int /*retryCount*/)
-{
-        return RetryOnFailureOperation<std::map<std::string, std::string> >::transportFactory->getTransport(cacheName);
-}
-
 std::map<std::string, std::string> StatsOperation::executeOperation(Transport& transport)
 {
     TRACE("Executing Stats");

--- a/src/hotrod/impl/operations/StatsOperation.h
+++ b/src/hotrod/impl/operations/StatsOperation.h
@@ -27,8 +27,6 @@ class StatsOperation : public RetryOnFailureOperation<std::map<std::string, std:
             Topology&                                 topologyId_,
             uint32_t                                   flags_);
 
-        infinispan::hotrod::transport::Transport& getTransport(int retryCount);
-
         std::map<std::string, std::string> executeOperation(infinispan::hotrod::transport::Transport& transport);
     private:
 

--- a/src/hotrod/impl/transport/TransportFactory.h
+++ b/src/hotrod/impl/transport/TransportFactory.h
@@ -34,8 +34,8 @@ class TransportFactory
     virtual void start(protocol::Codec& codec, int defaultTopologyId) = 0;
     virtual void destroy() = 0;
 
-    virtual Transport& getTransport(const std::vector<char>& cacheName) = 0;
-    virtual Transport& getTransport(const std::vector<char>& key, const std::vector<char>& cacheName) = 0;
+    virtual Transport& getTransport(const std::vector<char>& cacheName, const std::set<InetSocketAddress>& failedServers) = 0;
+    virtual Transport& getTransport(const std::vector<char>& key, const std::vector<char>& cacheName, const std::set<InetSocketAddress>& failedServers) = 0;
     virtual ClusterStatus clusterSwitch() = 0;
     virtual ClusterStatus clusterSwitch(std::string) = 0;
     virtual void releaseTransport(Transport& transport) = 0;

--- a/src/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.cpp
+++ b/src/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.cpp
@@ -20,7 +20,7 @@ void RoundRobinBalancingStrategy::setServers(const std::vector<transport::InetSo
     }
 }
 
-const transport::InetSocketAddress& RoundRobinBalancingStrategy::nextServer() {
+const transport::InetSocketAddress& RoundRobinBalancingStrategy::nextServer(const std::set<transport::InetSocketAddress>& /*failedServer*/) {
     const transport::InetSocketAddress& server = getServerByIndex(index++);
     if (index >= servers.size()) {
        index = 0;

--- a/src/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.h
+++ b/src/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.h
@@ -2,6 +2,7 @@
 #define ISPN_HOTROD_TRANSPORT_ROUNDROBINBALANCINGSTRATEGY_H
 
 #include "infinispan/hotrod/FailOverRequestBalancingStrategy.h"
+#include <set>
 
 namespace infinispan {
 namespace hotrod {
@@ -12,7 +13,7 @@ class RoundRobinBalancingStrategy : public FailOverRequestBalancingStrategy
   public:
 	RoundRobinBalancingStrategy();
     void setServers(const std::vector<transport::InetSocketAddress>& servers);
-    const transport::InetSocketAddress& nextServer();
+    const transport::InetSocketAddress& nextServer(const std::set<transport::InetSocketAddress>& failedServer);
 	static FailOverRequestBalancingStrategy* newInstance();
 
   private:

--- a/src/hotrod/impl/transport/tcp/TcpTransportFactory.h
+++ b/src/hotrod/impl/transport/tcp/TcpTransportFactory.h
@@ -27,8 +27,8 @@ class TcpTransportFactory : public TransportFactory
     void start(protocol::Codec& codec, int defaultTopologyId);
     void destroy();
 
-    Transport& getTransport(const std::vector<char>& cacheName);
-    Transport& getTransport(const std::vector<char>& key, const std::vector<char>& cacheName);
+    transport::Transport& getTransport(const std::vector<char>& cacheName, const std::set<transport::InetSocketAddress>& failedServers);
+    transport::Transport& getTransport(const std::vector<char>& key, const std::vector<char>& cacheName, const std::set<transport::InetSocketAddress>& failedServers);
 
     void releaseTransport(Transport& transport);
     void invalidateTransport(

--- a/src/hotrod/sys/SChannelSocket.h
+++ b/src/hotrod/sys/SChannelSocket.h
@@ -65,9 +65,9 @@ namespace infinispan {
 				CredHandle        hCred;
 				struct _SecHandle hCtxt;
 				CtxtHandle   hContext;
-				PBYTE        pbRBuffer;
-				PBYTE        pbWBuffer;
-				PBYTE        recvBuff;
+				PBYTE        pbRBuffer= NULL;
+				PBYTE        pbWBuffer= NULL;
+				PBYTE        recvBuff= NULL;
 				DWORD        cbRBuffer;
 				unsigned int ready_bytes=0;
 				unsigned int offset_bytes=0;

--- a/test/Simple.cpp
+++ b/test/Simple.cpp
@@ -20,10 +20,11 @@ namespace infinispan {
     namespace hotrod {
         namespace transport {
 
-            class MyRoundRobinBalancingStrategy : public FailOverRequestBalancingStrategy
-            {
+class MyRoundRobinBalancingStrategy: public FailOverRequestBalancingStrategy {
             public:
-                MyRoundRobinBalancingStrategy() : index(0) { }
+	MyRoundRobinBalancingStrategy() :
+			index(0) {
+	}
 
                 static FailOverRequestBalancingStrategy *newInstance() {
                     return new MyRoundRobinBalancingStrategy();
@@ -37,7 +38,8 @@ namespace infinispan {
                     }
                 }
 
-                ~MyRoundRobinBalancingStrategy() { }
+	~MyRoundRobinBalancingStrategy() {
+	}
 
                 const transport::InetSocketAddress &getServerByIndex(size_t pos) {
                     const transport::InetSocketAddress &server = servers[pos];
@@ -46,18 +48,27 @@ namespace infinispan {
             private:
                 std::vector<transport::InetSocketAddress> servers;
                 size_t index;
-                const transport::InetSocketAddress &nextServer() {
-                    const transport::InetSocketAddress &server = getServerByIndex(index++);
+	const transport::InetSocketAddress &nextServer(
+			const std::set<transport::InetSocketAddress>& failedServers) {
+		for (unsigned int i = 0; i <= servers.size(); i++) {
+			const transport::InetSocketAddress &server = getServerByIndex(
+					index++);
+			if (failedServers.empty() || failedServers.find(server)!=failedServers.end() || i>failedServers.size()) {
                     if (index >= servers.size()) {
                         index = 0;
+				}
                     }
                     return server;
                 }
 
 
+		throw Exception("Bad news, no server available.");
+	}
             };
 
-        }}}
+}
+}
+}
 
 
 template <class T>


### PR DESCRIPTION
Failover balancing needs the list of failed servers to work correctly. 
Fix for https://issues.jboss.org/browse/HRCPP-315
