### PR TITLE
HRCPP-319 # Removed include of Transport.h

### DIFF
--- a/include/infinispan/hotrod/CacheClientListener.h
+++ b/include/infinispan/hotrod/CacheClientListener.h
@@ -12,7 +12,6 @@
 #include "infinispan/hotrod/ImportExport.h"
 #include "infinispan/hotrod/ClientListener.h"
 #include "infinispan/hotrod/RemoteCacheBase.h"
-#include "hotrod/impl/transport/Transport.h"
 #include <vector>
 #include <list>
 #include <functional>


### PR DESCRIPTION
This is a fix for https://issues.jboss.org/browse/HRCPP-319