### PR TITLE
HRCPP-322 # Cluster switch methods now same as Java

### DIFF
--- a/include/infinispan/hotrod/RemoteCacheManager.h
+++ b/include/infinispan/hotrod/RemoteCacheManager.h
@@ -279,7 +279,7 @@ public:
      * \return ClusterStatus::SWITCHED or ClusterStatus::NOT_SWITCHED if no fully working
      * cluster is available
      */
-    ClusterStatus clusterSwitch();
+    bool switchToDefaultCluster();
 
     /**
      * Switch the client on the main cluster
@@ -287,7 +287,7 @@ public:
      * \return ClusterStatus::SWITCHED or ClusterStatus::NOT_SWITCHED if the named cluster
      * doesn't exists
      */
-    ClusterStatus clusterSwitch(std::string clusterName);
+    bool switchToCluster(std::string clusterName);
 
 private:
     void *impl;

--- a/src/hotrod/api/RemoteCacheManager.cpp
+++ b/src/hotrod/api/RemoteCacheManager.cpp
@@ -57,11 +57,11 @@ const Configuration& RemoteCacheManager::getConfiguration() {
     return IMPL->getConfiguration();
 }
 
-ClusterStatus RemoteCacheManager::clusterSwitch()
+bool RemoteCacheManager::switchToDefaultCluster()
 {
   return IMPL->clusterSwitch();
 }
-ClusterStatus RemoteCacheManager::clusterSwitch(std::string clusterName)
+bool RemoteCacheManager::switchToCluster(std::string clusterName)
 {
 	return IMPL->clusterSwitch(clusterName);
 }

--- a/src/hotrod/impl/RemoteCacheManagerImpl.cpp
+++ b/src/hotrod/impl/RemoteCacheManagerImpl.cpp
@@ -145,12 +145,12 @@ PingResult RemoteCacheManagerImpl::ping(RemoteCacheImpl& remoteCache) {
     return remoteCache.ping();
 }
 
-ClusterStatus RemoteCacheManagerImpl::clusterSwitch(std::string clusterName)
+bool RemoteCacheManagerImpl::clusterSwitch(std::string clusterName)
 {
 	return transportFactory->clusterSwitch(clusterName);
 }
 
-ClusterStatus RemoteCacheManagerImpl::clusterSwitch()
+bool RemoteCacheManagerImpl::clusterSwitch()
 {
 	return transportFactory->clusterSwitch();
 }

--- a/src/hotrod/impl/RemoteCacheManagerImpl.h
+++ b/src/hotrod/impl/RemoteCacheManagerImpl.h
@@ -29,8 +29,8 @@ class RemoteCacheManagerImpl
     void stop();
     bool isStarted();
     const Configuration& getConfiguration();
-    ClusterStatus clusterSwitch();
-    ClusterStatus clusterSwitch(std::string clusterName);
+    bool clusterSwitch();
+    bool clusterSwitch(std::string clusterName);
 
     ClientListenerNotifier*& getListenerNotifier() {
 		return listenerNotifier;

--- a/src/hotrod/impl/operations/RetryOnFailureOperation.h
+++ b/src/hotrod/impl/operations/RetryOnFailureOperation.h
@@ -68,7 +68,7 @@ template<class T> class RetryOnFailureOperation : public HotRodOperation<T>
 	void logErrorAndThrowExceptionIfNeeded(int& retryCount,
 			const HotRodClientException& e) {
 		if (retryCount >= transportFactory->getMaxRetries() - 1) {
-			if (transportFactory->clusterSwitch() == ClusterStatus::SWITCHED) {
+			if (transportFactory->clusterSwitch()) {
 				retryCount = 0; // reset retry counter
 			} else {
 				ERROR("Exception encountered, retry %d of %d: %s", retryCount,

--- a/src/hotrod/impl/transport/TransportFactory.h
+++ b/src/hotrod/impl/transport/TransportFactory.h
@@ -37,8 +37,8 @@ class TransportFactory
 
     virtual Transport& getTransport(const std::vector<char>& cacheName, const std::set<InetSocketAddress>& failedServers) = 0;
     virtual Transport& getTransport(const std::vector<char>& key, const std::vector<char>& cacheName, const std::set<InetSocketAddress>& failedServers) = 0;
-    virtual ClusterStatus clusterSwitch() = 0;
-    virtual ClusterStatus clusterSwitch(std::string) = 0;
+    virtual bool clusterSwitch() = 0;
+    virtual bool clusterSwitch(std::string) = 0;
     virtual void releaseTransport(Transport& transport) = 0;
     virtual void invalidateTransport(
         const InetSocketAddress& serverAddress, Transport* transport) = 0;

--- a/src/hotrod/impl/transport/tcp/TcpTransportFactory.cpp
+++ b/src/hotrod/impl/transport/tcp/TcpTransportFactory.cpp
@@ -123,12 +123,12 @@ void TcpTransportFactory::invalidateTransport(
     pool->invalidateObject(serverAddress, dynamic_cast<TcpTransport*>(transport));
 }
 
-ClusterStatus TcpTransportFactory::clusterSwitch()
+bool TcpTransportFactory::clusterSwitch()
 {
     auto configuredServers = getNextWorkingServersConfiguration();
 	if (configuredServers.size()==0)
 	{
-		return NOT_SWITCHED;
+		return false;
 	}
 	connectionPool->close();
 	ScopedLock<Mutex> l(lock);
@@ -154,14 +154,14 @@ ClusterStatus TcpTransportFactory::clusterSwitch()
 
     balancer->setServers(initialServers);
     pingServers();
-    return SWITCHED;
+    return true;
 }
 
-ClusterStatus TcpTransportFactory::clusterSwitch(std::string clusterName)
+bool TcpTransportFactory::clusterSwitch(std::string clusterName)
 {
 	auto servers=configuration.getServersMapConfiguration();
 	if (servers.find(clusterName)==servers.end())
-		return NOT_SWITCHED;
+		return false;
     auto configuredServers = servers[clusterName];
 	ScopedLock<Mutex> l(lock);
 	topologyAge = 0;
@@ -188,7 +188,7 @@ ClusterStatus TcpTransportFactory::clusterSwitch(std::string clusterName)
 
     balancer->setServers(initialServers);
     pingServers();
-    return SWITCHED;
+    return true;
 }
 
 bool TcpTransportFactory::isTcpNoDelay() {

--- a/src/hotrod/impl/transport/tcp/TcpTransportFactory.h
+++ b/src/hotrod/impl/transport/tcp/TcpTransportFactory.h
@@ -33,8 +33,8 @@ class TcpTransportFactory : public TransportFactory
     void releaseTransport(Transport& transport);
     void invalidateTransport(
         const InetSocketAddress& address, Transport* transport);
-    ClusterStatus clusterSwitch();
-    ClusterStatus clusterSwitch(std::string clusterName);
+    bool clusterSwitch();
+    bool clusterSwitch(std::string clusterName);
     bool isTcpNoDelay();
     int getMaxRetries();
     int getSoTimeout();


### PR DESCRIPTION
This is a fix for https://issues.jboss.org/browse/HRCPP-322.
Changed the RemoteCacheManager cluster switch method signatures to be equal with the Java ones