### PR TITLE
HRCPP-329 # fix for default switch

### DIFF
--- a/src/hotrod/api/RemoteCacheManager.cpp
+++ b/src/hotrod/api/RemoteCacheManager.cpp
@@ -59,7 +59,7 @@ const Configuration& RemoteCacheManager::getConfiguration() {
 
 bool RemoteCacheManager::switchToDefaultCluster()
 {
-  return IMPL->clusterSwitch();
+  return IMPL->clusterSwitch(Configuration::DEFAULT_CLUSTER_NAME);
 }
 bool RemoteCacheManager::switchToCluster(std::string clusterName)
 {


### PR DESCRIPTION
DEFAULT_CLUSTER_NAME must be explicitly passed to the clusterSwitch method.

this is a fix for https://issues.jboss.org/browse/HRCPP-329
