### PR TITLE
HRCPP-296 # added querystring methods

### DIFF
--- a/include/infinispan/hotrod/Query.h
+++ b/include/infinispan/hotrod/Query.h
@@ -1,0 +1,40 @@
+/*
+ * Query.h
+ *
+ *  Created on: Nov 23, 2016
+ *      Author: rigazilla
+ */
+
+#ifndef INCLUDE_INFINISPAN_HOTROD_QUERY_H_
+#define INCLUDE_INFINISPAN_HOTROD_QUERY_H_
+#include "query.pb.h"
+#include <tuple>
+
+using namespace org::infinispan::protostream;
+
+namespace org {
+namespace infinispan {
+namespace query {
+namespace remote {
+namespace client {
+
+// jpqlstring field has been renamed to querystring
+// in the .proto file.
+// This class mantains backward compatibility
+class QueryRequest : public QueryRequestProtobuf
+{
+public:
+  inline bool has_jpqlstring() const { return has_querystring(); }
+  inline void clear_jpqlstring() { clear_querystring(); }
+  inline const ::std::string& jpqlstring() const { return querystring(); }
+  inline void set_jpqlstring(const ::std::string& value) { set_querystring(value); }
+  inline void set_jpqlstring(const char* value) { set_querystring(value); }
+  inline void set_jpqlstring(const char* value, size_t size) { set_querystring(value, size); }
+  inline ::std::string* mutable_jpqlstring() { return mutable_querystring(); }
+  inline ::std::string* release_jpqlstring() { return release_querystring(); }
+  inline void set_allocated_jpqlstring(::std::string* querystring) { set_allocated_querystring(querystring); }
+};
+
+}}}}}
+
+#endif /* INCLUDE_INFINISPAN_HOTROD_QUERY_H_ */

--- a/include/infinispan/hotrod/QueryUtils.h
+++ b/include/infinispan/hotrod/QueryUtils.h
@@ -7,14 +7,8 @@
 
 #ifndef INCLUDE_INFINISPAN_HOTROD_QUERYUTILS_H_
 #define INCLUDE_INFINISPAN_HOTROD_QUERYUTILS_H_
-#if _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4267 4244)
-#endif
-#include "query.pb.h"
-#if _MSC_VER
-#pragma warning(pop)
-#endif
+
+#include "infinispan/hotrod/Query.h"
 #include <tuple>
 using namespace org::infinispan::protostream;
 

--- a/include/infinispan/hotrod/RemoteCache.h
+++ b/include/infinispan/hotrod/RemoteCache.h
@@ -1,8 +1,6 @@
 #ifndef ISPN_HOTROD_REMOTECACHE_H
 #define ISPN_HOTROD_REMOTECACHE_H
 
-
-
 #include "infinispan/hotrod/RemoteCacheBase.h"
 #include "infinispan/hotrod/Marshaller.h"
 #include "infinispan/hotrod/Flag.h"
@@ -12,15 +10,7 @@
 #include "infinispan/hotrod/Version.h"
 #include "infinispan/hotrod/exceptions.h"
 #include "infinispan/hotrod/ClientListener.h"
-#if _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4267 4244)
-#endif
-#include "query.pb.h"
-#if _MSC_VER
-#pragma warning(pop)
-#endif
-
+#include "infinispan/hotrod/Query.h"
 #include <cmath>
 #include <set>
 #include <map>

--- a/include/infinispan/hotrod/RemoteCacheBase.h
+++ b/include/infinispan/hotrod/RemoteCacheBase.h
@@ -9,15 +9,7 @@
 #include "infinispan/hotrod/Flag.h"
 #include "infinispan/hotrod/MetadataValue.h"
 #include "infinispan/hotrod/portable.h"
-#if _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4267 4244)
-#endif
-#include "query.pb.h"
-#if _MSC_VER
-#pragma warning(pop)
-#endif
-
+#include "infinispan/hotrod/Query.h"
 #include <map>
 #include <set>
 #include <vector>

--- a/proto/org/infinispan/query/remote/client/query.proto
+++ b/proto/org/infinispan/query/remote/client/query.proto
@@ -5,15 +5,15 @@ package org.infinispan.query.remote.client;
 /**
  * @TypeId(1000101)
  */
-message QueryRequest {
+message QueryRequestProtobuf {
 
    /**
-    * The query string, expressed in JPA query language.
+    * The query string, expressed in Infinispan's query language (a JPA subset with full-text enhancements).
     * NOTE: currently only a limited subset of the JPA query language is supported.
     */
-   required string jpqlString = 1;
+   required string queryString = 1;
 
-   // NOTE: id 2 was used for sort criteria, which is now into the ORDER BY clause inside the jpqlString
+   // NOTE: id 2 was used for sort criteria, which is now into the ORDER BY clause inside the query string
 
    /**
     * The number of matching results to skip before the first returned result.
@@ -90,13 +90,20 @@ message FilterResult {
  */
 message ContinuousQueryResult {
 
-   required bool isJoining = 1;
+   /* @TypeId(1000105) */
+   enum ResultType {
+      JOINING = 1;
+      LEAVING = 0;
+      UPDATED = 2;
+   }
+
+   required ResultType resultType = 1;
 
    required bytes key = 2;
 
-   /* Only present if joining == true and projection is missing */
+   /* Only present if resultType is JOINING or UPDATED and projection is missing */
    optional bytes value = 3;
 
-   /* Only present if joining == true and value is missing */
+   /* Only present if jresultType is JOINING or UPDATED and value is missing */
    repeated org.infinispan.protostream.WrappedMessage projection = 4;
 }

--- a/src/hotrod/api/RemoteCacheBase.cpp
+++ b/src/hotrod/api/RemoteCacheBase.cpp
@@ -3,8 +3,7 @@
 #include "infinispan/hotrod/RemoteCacheBase.h"
 #include "infinispan/hotrod/RemoteCacheManager.h"
 #include "hotrod/impl/RemoteCacheImpl.h"
-#include "query.pb.h"
-
+#include "infinispan/hotrod/Query.h"
 #include <iostream>
 
 namespace infinispan {

--- a/src/hotrod/impl/RemoteCacheImpl.h
+++ b/src/hotrod/impl/RemoteCacheImpl.h
@@ -6,14 +6,7 @@
 #include "hotrod/impl/MetadataValueImpl.h"
 #include "hotrod/impl/VersionedValueImpl.h"
 #include "hotrod/impl/operations/PingOperation.h"
-#if _MSVC_VER
-#pragma warning(push)
-#pragma warning(disable:4267 4244)
-#endif
-#include "query.pb.h"
-#if _MSVC_VER
-#pragma warning(pop)
-#endif
+#include "infinispan/hotrod/Query.h"
 
 using namespace org::infinispan::query::remote::client;
 

--- a/src/hotrod/impl/operations/OperationsFactory.h
+++ b/src/hotrod/impl/operations/OperationsFactory.h
@@ -5,15 +5,7 @@
 #include "infinispan/hotrod/Flag.h"
 
 #include <infinispan/hotrod/portable.h>
-#if _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4267 4244)
-#endif
-#include <query.pb.h>
-#if _MSC_VER
-#pragma warning(pop)
-#endif
-
+#include "infinispan/hotrod/Query.h"
 #include "infinispan/hotrod/ClientListener.h"
 #include <set>
 #include <functional>

--- a/src/hotrod/impl/operations/QueryOperation.h
+++ b/src/hotrod/impl/operations/QueryOperation.h
@@ -9,14 +9,7 @@
 #define SRC_HOTROD_IMPL_OPERATIONS_QUERYOPERATION_H_
 
 #include "hotrod/impl/operations/RetryOnFailureOperation.h"
-#if _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4267 4244)
-#endif
-#include "query.pb.h"
-#if _MSC_VER
-#pragma warning(pop)
-#endif
+#include "infinispan/hotrod/Query.h"
 #include <memory>
 namespace infinispan {
 namespace hotrod {

--- a/test/QueryTest.cpp
+++ b/test/QueryTest.cpp
@@ -12,14 +12,7 @@
 #include "infinispan/hotrod/RemoteCacheManager.h"
 #include "infinispan/hotrod/RemoteCache.h"
 #include "infinispan/hotrod/Version.h"
-#if _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4267 4244)
-#endif
-#include "query.pb.h"
-#if _MSC_VER
-#pragma warning(pop)
-#endif
+#include "infinispan/hotrod/Query.h"
 #include "infinispan/hotrod/QueryUtils.h"
 #include <vector>
 #include <tuple>
@@ -32,17 +25,17 @@ using namespace org::infinispan::query::remote::client;
 
 std::string read(std::string file)
 {
-	std::ifstream t(file);
-	std::stringstream buffer;
-	buffer << t.rdbuf();
-	return buffer.str();
+    std::ifstream t(file);
+    std::stringstream buffer;
+    buffer << t.rdbuf();
+    return buffer.str();
 }
 
 
 int main(int argc, char** argv) {
 
     int result=0;
-	std::cout << "Tests for Query" << std::endl;
+    std::cout << "Tests for Query" << std::endl;
     ConfigurationBuilder builder;
     builder.addServer().host(argc > 1 ? argv[1] : "127.0.0.1").port(argc > 2 ? atoi(argv[2]) : 11222);
     builder.protocolVersion(Configuration::PROTOCOL_VERSION_24);
@@ -55,21 +48,21 @@ int main(int argc, char** argv) {
     auto *vm = new BasicTypesProtoStreamMarshaller<std::string>();
 
     RemoteCache<std::string, std::string> metadataCache = cacheManager.getCache<std::string, std::string>(
-    		km, &Marshaller<std::string>::destroy, vm, &Marshaller<std::string>::destroy,PROTOBUF_METADATA_CACHE_NAME, false);
+            km, &Marshaller<std::string>::destroy, vm, &Marshaller<std::string>::destroy,PROTOBUF_METADATA_CACHE_NAME, false);
 
 
     metadataCache.put("sample_bank_account/bank.proto", read("query_proto/bank.proto"));
     if (metadataCache.containsKey(ERRORS_KEY_SUFFIX))
-	{
+    {
       std::cerr << "fail: error in registering .proto model" << std::endl;
       result=-1;
       return result;
-	}
+    }
 
     auto *testkm = new BasicTypesProtoStreamMarshaller<int>();
     auto *testvm = new ProtoStreamMarshaller<sample_bank_account::User>();
     RemoteCache<int, sample_bank_account::User> testCache = cacheManager.getCache<int, sample_bank_account::User>(
-    		testkm, &Marshaller<int>::destroy, testvm, &Marshaller<sample_bank_account::User>::destroy, "namedCache", false);
+            testkm, &Marshaller<int>::destroy, testvm, &Marshaller<sample_bank_account::User>::destroy, "namedCache", false);
     testCache.clear();
     sample_bank_account::User_Address a;
     sample_bank_account::User user1;
@@ -89,83 +82,88 @@ int main(int argc, char** argv) {
     user1.set_gender(sample_bank_account::User_Gender_MALE);
     testCache.put(4, user1);
 
-	{
-		QueryRequest qr;
-		qr.set_jpqlstring("from sample_bank_account.User");
-		QueryResponse resp = testCache.query(qr);
+    {
+        QueryRequest qr;
+        // set_jpqlstring will be soon deprecated use set_querystring
+        // qr.set_jpqlstring("from sample_bank_account.User");
+        qr.set_querystring("from sample_bank_account.User");
+        QueryResponse resp = testCache.query(qr);
 
-		std::vector<sample_bank_account::User> res;
-		if (!unwrapResults(resp, res)) {
-			std::cerr << "fail: found unexpected projection in resultset"
-					<< std::endl;
-			result = -1;
-			return result;
-		}
+        std::vector<sample_bank_account::User> res;
+        if (!unwrapResults(resp, res)) {
+            std::cerr << "fail: found unexpected projection in resultset"
+                    << std::endl;
+            result = -1;
+            return result;
+        }
 
-		if (res.size() != 2) {
-			std::cerr << "fail: expected 2 got " << res.size() << std::endl;
-			result = -1;
-			return result;
-		}
+        if (res.size() != 2) {
+            std::cerr << "fail: expected 2 got " << res.size() << std::endl;
+            result = -1;
+            return result;
+        }
 
-		for (unsigned int i = 0; i < res.size(); i++) {
-			std::cout << "User(id=" << res[i].id() << ",name=" << res[i].name()
-					<< ",surname=" << res[i].surname() << ")" << std::endl;
-		}
-	}
+        for (unsigned int i = 0; i < res.size(); i++) {
+            std::cout << "User(id=" << res[i].id() << ",name=" << res[i].name()
+                    << ",surname=" << res[i].surname() << ")" << std::endl;
+        }
+    }
 #if !defined (_MSC_VER) || (_MSC_VER>=1800)
-	{
-		QueryRequest qr;
-		qr.set_jpqlstring(
-				"select u.name, u.surname from sample_bank_account.User u");
-		QueryResponse resp = testCache.query(qr);
+    {
+        QueryRequest qr;
+        // set_jpqlstring will be soon deprecated use set_querystring
+        // qr.set_jpqlstring("select u.name, u.surname from sample_bank_account.User u");
+        qr.set_querystring("select u.name, u.surname from sample_bank_account.User u");
+        QueryResponse resp = testCache.query(qr);
 
-		std::vector<std::tuple<std::string, std::string> > prjRes;
+        std::vector<std::tuple<std::string, std::string> > prjRes;
 
-		if (!unwrapProjection(resp, prjRes)) {
-			std::cerr << "fail: projection not found" << std::endl;
-			result = -1;
-			return result;
-		}
+        if (!unwrapProjection(resp, prjRes)) {
+            std::cerr << "fail: projection not found" << std::endl;
+            result = -1;
+            return result;
+        }
 
-		for (unsigned int i = 0; i < prjRes.size(); i++) {
-			std::cout << std::get < 0 > (prjRes[i]) << "  " << std::get < 1
-					> (prjRes[i]) << "  " << std::endl;
-		}
-	}
+        for (unsigned int i = 0; i < prjRes.size(); i++) {
+            std::cout << std::get < 0 > (prjRes[i]) << "  " << std::get < 1
+                    > (prjRes[i]) << "  " << std::endl;
+        }
+    }
 
-	{
-		QueryRequest qr;
-		qr.set_jpqlstring(
-				"select u.surname, u.id from sample_bank_account.User u");
-		QueryResponse resp = testCache.query(qr);
+    {
+        QueryRequest qr;
+        // set_jpqlstring will be soon deprecated use set_querystring
+        // qr.set_jpqlstring("select u.surname, u.id from sample_bank_account.User u");
+        qr.set_querystring("select u.surname, u.id from sample_bank_account.User u");
+        QueryResponse resp = testCache.query(qr);
 
-		std::vector<std::tuple<std::string, int> > prjRes;
+        std::vector<std::tuple<std::string, int> > prjRes;
 
-		if (!unwrapProjection(resp, prjRes)) {
-			std::cerr << "fail: projection not found" << std::endl;
-			result = -1;
-			return result;
-		}
+        if (!unwrapProjection(resp, prjRes)) {
+            std::cerr << "fail: projection not found" << std::endl;
+            result = -1;
+            return result;
+        }
 
-		for (unsigned int i = 0; i < prjRes.size(); i++) {
-			std::cout << std::get < 0 > (prjRes[i]) << "  " << std::get < 1
-					> (prjRes[i]) << "  " << std::endl;
-		}
-	}
+        for (unsigned int i = 0; i < prjRes.size(); i++) {
+            std::cout << std::get < 0 > (prjRes[i]) << "  "
+                << std::get<1>(prjRes[i]) << "  " << std::endl;
+        }
+    }
 #endif
-	{
-		QueryRequest qr;
-		qr.set_jpqlstring(
-				"select count(u.surname) from sample_bank_account.User u");
-		QueryResponse resp = testCache.query(qr);
+    {
+        QueryRequest qr;
+        // set_jpqlstring will be soon deprecated use set_querystring
+        // qr.set_jpqlstring("select count(u.surname) from sample_bank_account.User u");
+        qr.set_querystring("select count(u.surname) from sample_bank_account.User u");
+        QueryResponse resp = testCache.query(qr);
 
-		int i = unwrapSingleResult<int>(resp);
+        int i = unwrapSingleResult<int>(resp);
 
-			std::cout << "result is: " << i << std::endl;
-	}
+        std::cout << "result is: " << i << std::endl;
+    }
 
 
-	return result;
+    return result;
 }
 


### PR DESCRIPTION
This adds querystring field and accessors to the QueryRequest class.
Backward compatibility is preserved (i.e. jpqlstring and accessors are still availables)

Fix for https://issues.jboss.org/browse/HRCPP-296