### PR TITLE
HRCPP-341 # Fixed memleaks in nearCacheTest

### DIFF
--- a/include/infinispan/hotrod/RemoteCacheManager.h
+++ b/include/infinispan/hotrod/RemoteCacheManager.h
@@ -117,9 +117,9 @@ public:
             pRc= new RemoteCache<K,V>();
             remoteCacheMap[key]= std::unique_ptr<RemoteCacheBase>(pRc);
             RemoteCache<K, V> *rcache=(RemoteCache<K, V> *)remoteCacheMap[key].get();
-            initCache(*rcache, forceReturnValue, getConfiguration().getNearCacheConfiguration());
             rcache->keyMarshaller.reset(new BasicMarshaller<K>());
             rcache->valueMarshaller.reset(new BasicMarshaller<V>());
+            initCache(*rcache, forceReturnValue, getConfiguration().getNearCacheConfiguration());
             return *rcache;
         }
         return *(RemoteCache<K, V> *)remoteCacheMap[key].get();
@@ -152,9 +152,9 @@ public:
             RemoteCache<K,V> *pRc= new RemoteCache<K,V>();
             remoteCacheMap[key]= std::unique_ptr<RemoteCacheBase>(pRc);
             RemoteCache<K, V> *rcache=(RemoteCache<K, V> *)remoteCacheMap[key].get();
-            initCache(*rcache, name.c_str(), forceReturnValue);
             rcache->keyMarshaller.reset(new BasicMarshaller<K>());
             rcache->valueMarshaller.reset(new BasicMarshaller<V>());
+            initCache(*rcache, name.c_str(), forceReturnValue);
             return *rcache;
         }
         return *(RemoteCache<K, V> *)remoteCacheMap[key].get();
@@ -190,18 +190,12 @@ public:
         if (remoteCacheMap.find(key) == remoteCacheMap.end()) {
             RemoteCache<K, V> *pRc = new RemoteCache<K, V>();
             remoteCacheMap[key] = std::unique_ptr < RemoteCacheBase > (pRc);
-            RemoteCache<K, V> *rcache =
-                    (RemoteCache<K, V> *) remoteCacheMap[key].get();
-            initCache(*rcache, forceReturnValue, getConfiguration().getNearCacheConfiguration());
-            rcache->keyMarshaller.reset(km);
-            rcache->valueMarshaller.reset(vm);
-            return *rcache;
         }
         RemoteCache<K, V> *rcache =
                 (RemoteCache<K, V> *) remoteCacheMap[key].get();
-        initCache(*rcache, forceReturnValue, getConfiguration().getNearCacheConfiguration());
         rcache->keyMarshaller.reset(km);
         rcache->valueMarshaller.reset(vm);
+        initCache(*rcache, forceReturnValue, getConfiguration().getNearCacheConfiguration());
         return *rcache;
     }
 
@@ -242,18 +236,12 @@ public:
         if (remoteCacheMap.find(key) == remoteCacheMap.end()) {
             RemoteCache<K, V> *pRc = new RemoteCache<K, V>();
             remoteCacheMap[key] = std::unique_ptr < RemoteCacheBase > (pRc);
-            RemoteCache<K, V> *rcache =
-                    (RemoteCache<K, V> *) remoteCacheMap[key].get();
-            initCache(*rcache, name.c_str(), forceReturnValue, getConfiguration().getNearCacheConfiguration());
-            rcache->keyMarshaller.reset(km);
-            rcache->valueMarshaller.reset(vm);
-            return *rcache;
         }
         RemoteCache<K, V> *rcache =
                 (RemoteCache<K, V> *) remoteCacheMap[key].get();
-        initCache(*rcache, name.c_str(), forceReturnValue, getConfiguration().getNearCacheConfiguration());
         rcache->keyMarshaller.reset(km);
         rcache->valueMarshaller.reset(vm);
+        initCache(*rcache, name.c_str(), forceReturnValue, getConfiguration().getNearCacheConfiguration());
         return *rcache;
     }
 

--- a/src/hotrod/impl/RemoteCacheImpl.cpp
+++ b/src/hotrod/impl/RemoteCacheImpl.cpp
@@ -262,13 +262,13 @@ void RemoteCacheImpl::addClientListener(ClientListener& clientListener, const st
 	// Special behaviour for this operation. op will be keep by the dispatcher and reused if needed
 	// so op is not to be destroyed here.
 	// TODO: Maybe a good move semantic implementation for Add operation can uniform the code
-    auto op = operationsFactory->newAddClientListenerOperation(clientListener, *remoteCacheManager.getListenerNotifier(), filterFactoryParam, converterFactoryParams, recoveryCallback);
+    auto op = std::shared_ptr<AddClientListenerOperation>(operationsFactory->newAddClientListenerOperation(clientListener, remoteCacheManager.getListenerNotifier(), filterFactoryParam, converterFactoryParams, recoveryCallback));
     op->execute();
 }
 
 void RemoteCacheImpl::removeClientListener(ClientListener& clientListener)
 {
-    RemoveClientListenerOperation *rclo = operationsFactory->newRemoveClientListenerOperation(clientListener, *remoteCacheManager.getListenerNotifier());
+    RemoveClientListenerOperation *rclo = operationsFactory->newRemoveClientListenerOperation(clientListener, remoteCacheManager.getListenerNotifier());
     std::unique_ptr<RemoveClientListenerOperation> op(rclo);
     op->execute();
 }

--- a/src/hotrod/impl/RemoteCacheManagerImpl.h
+++ b/src/hotrod/impl/RemoteCacheManagerImpl.h
@@ -32,8 +32,8 @@ class RemoteCacheManagerImpl
     bool clusterSwitch();
     bool clusterSwitch(std::string clusterName);
 
-    ClientListenerNotifier*& getListenerNotifier() {
-		return listenerNotifier;
+    ClientListenerNotifier& getListenerNotifier() {
+		return *listenerNotifier;
 	}
   private:
     sys::Mutex lock;
@@ -47,7 +47,7 @@ class RemoteCacheManagerImpl
 
     operations::PingResult ping(RemoteCacheImpl& remoteCache);
     std::shared_ptr<transport::TransportFactory> transportFactory;
-    ClientListenerNotifier *listenerNotifier;
+    std::shared_ptr<ClientListenerNotifier> listenerNotifier;
 
     void startRemoteCache(RemoteCacheImpl& remoteCache, bool forceReturnValue);
 };

--- a/src/hotrod/impl/event/ClientListenerNotifier.h
+++ b/src/hotrod/impl/event/ClientListenerNotifier.h
@@ -17,7 +17,6 @@
 using namespace infinispan::hotrod::protocol;
 using namespace infinispan::hotrod::transport;
 
-
 namespace infinispan {
 namespace hotrod {
 namespace event {
@@ -25,18 +24,19 @@ namespace event {
 class ClientListenerNotifier {
 public:
 	virtual ~ClientListenerNotifier();
-	void addClientListener(const std::vector<char> listenerId, const ClientListener& clientListener, const std::vector<char> cacheName, Transport& t, const Codec20& codec20, void* operationPtr, const std::function<void()> &recoveryCallback);
+	void addClientListener(const std::vector<char> listenerId, const ClientListener& clientListener, const std::vector<char> cacheName,  Transport& t, const Codec20& codec20, std::shared_ptr<void> operationPtr, const std::function<void()> &recoveryCallback);
 	void removeClientListener(const std::vector<char> listenerId);
 	void startClientListener(const std::vector<char> listenerId);
 	const ClientListener& findClientListener(const std::vector<char> listenerId);
 	const Transport& findClientListenerTransport(const std::vector<char> listenerId);
-	static ClientListenerNotifier* create();
+	static ClientListenerNotifier* create(std::shared_ptr<TransportFactory> factory);
 	void failoverClientListeners(const std::vector<transport::InetSocketAddress>& failedServers);
 	void stop();
 protected:
-	ClientListenerNotifier();
+	ClientListenerNotifier(std::shared_ptr<TransportFactory> factory);
 private:
 	std::map<std::vector<char>, EventDispatcher> eventDispatchers;
+	std::shared_ptr<TransportFactory> transportFactory;
 };
 
 } /* namespace event */

--- a/src/hotrod/impl/event/EventDispatcher.cpp
+++ b/src/hotrod/impl/event/EventDispatcher.cpp
@@ -29,9 +29,7 @@ void EventDispatcher::start()
 void EventDispatcher::stop()
 {
    // This terminates the thread
-//   std::cout << "EventDispatcher::stop()" << std::endl;
-//   transport.release();
-//   std::cout << "EventDispatcher::stop() end" << std::endl;
+   transport.release();
 }
 
 void EventDispatcher::run() {
@@ -39,19 +37,14 @@ void EventDispatcher::run() {
 	while (true) {
 		try {
 			while (1) {
-				//uint64_t messageId;
-				status = 1;
 				EventHeaderParams params = codec20.readEventHeader(transport);
-				status = 2;
 				if (!(HotRodConstants::isEvent(params.opCode))) {
 					// TODO handle error in some way
 					break;
 				}
-				std::vector<char> listId = codec20.readEventListenerId(
-						transport);
+				std::vector<char> listId = codec20.readEventListenerId(transport);
 				uint8_t isCustom = codec20.readEventIsCustomFlag(transport);
 				uint8_t isRetried = codec20.readEventIsRetriedFlag(transport);
-				status = 3;
 				if (isCustom != 0) {
 					ClientCacheEntryCustomEvent ev = codec20.readCustomEvent(
 							transport, isRetried);
@@ -97,12 +90,9 @@ void EventDispatcher::run() {
 			if (ex.getErrnum() == EINTR) {
 				// count a retry
 				bool b = dynamic_cast<TcpTransport&>(transport).isValid();
-				if (retryCount++ <= 2 && b)
+				if (retryCount++ <= 1 && b)
 					continue;
 			}
-			transport.setValid(false);
-
-			status = 99;
 			if (recoveryCallback) {
 				recoveryCallback();
 			}

--- a/src/hotrod/impl/event/EventDispatcher.h
+++ b/src/hotrod/impl/event/EventDispatcher.h
@@ -32,16 +32,18 @@ template <class T> using X =  std::function<void(T)>;
 
 class EventDispatcher {
 public:
-	EventDispatcher(const std::vector<char> listenerId, const ClientListener& cl, std::vector<char> cacheName, Transport& t, const Codec20& codec20, void* addClientListenerOpPtr, const std::function<void()> &recoveryCallback) : listenerId(listenerId), cl(cl), operationPtr(addClientListenerOpPtr), cacheName(cacheName), transport(t), codec20(codec20), status(0), recoveryCallback(recoveryCallback)
+	EventDispatcher(const std::vector<char> listenerId, const ClientListener& cl, std::vector<char> cacheName, Transport &t, const Codec20& codec20, std::shared_ptr<void> addClientListenerOpPtr, const std::function<void()> &recoveryCallback) : listenerId(listenerId), cl(cl), operationPtr(addClientListenerOpPtr), cacheName(cacheName), transport(t), codec20(codec20), recoveryCallback(recoveryCallback)
     {}
 	virtual ~EventDispatcher() {
-		if (p_thread)
-		{
-			((TcpTransport&)transport).destroy();
-		   p_thread->join();
-		}
+	    if (p_thread)
+	    {
+	        if (p_thread->joinable())
+	        {
+	            p_thread->join();
+	        }
+        }
 	}
-	const Transport& getTransport() {
+	Transport& getTransport() {
 		return transport;
 	}
     void run();
@@ -49,14 +51,13 @@ public:
     void stop();
 	const std::vector<char> listenerId;
 	const ClientListener& cl;
-	void* const operationPtr;
+	const std::shared_ptr<void> operationPtr;
 
 private:
 	std::vector<char> cacheName;
-	Transport& transport;
+	Transport &transport;
 	const Codec20& codec20;
 	std::shared_ptr<std::thread> p_thread;
-	int status;
 	const std::function<void()> &recoveryCallback;
 };
 

--- a/src/hotrod/impl/operations/AddClientListenerOperation.h
+++ b/src/hotrod/impl/operations/AddClientListenerOperation.h
@@ -24,7 +24,7 @@ namespace infinispan {
 namespace hotrod {
 namespace operations {
 
-class AddClientListenerOperation: public RetryOnFailureOperation<char> {
+class AddClientListenerOperation: public RetryOnFailureOperation<char>, public std::enable_shared_from_this<AddClientListenerOperation> {
 public:
 	AddClientListenerOperation(const Codec &codec, std::shared_ptr<TransportFactory> transportFactory,
                              std::vector<char> cacheName, Topology& topologyId, int flags,
@@ -36,6 +36,8 @@ public:
 							 recoveryCallback(recoveryCallback), cacheName(cacheName)
 							 {};
     virtual void releaseTransport(transport::Transport* transport);
+    virtual void invalidateTransport(const infinispan::hotrod::transport::InetSocketAddress & addr, transport::Transport* transport);
+
     virtual transport::Transport& getTransport(int retryCount, const std::set<transport::InetSocketAddress>& failedServers);
 	char executeOperation(transport::Transport& transport);
     ClientListenerNotifier& listenerNotifier;
@@ -45,6 +47,7 @@ public:
     const std::vector<std::vector<char> > converterFactoryParams;
 
     const std::function<void()> recoveryCallback;
+    bool shared = false;
 private:
     const std::vector<char> cacheName;
     std::vector<char> generateV4UUID();

--- a/src/hotrod/impl/operations/RetryOnFailureOperation.h
+++ b/src/hotrod/impl/operations/RetryOnFailureOperation.h
@@ -32,7 +32,7 @@ template<class T> class RetryOnFailureOperation : public HotRodOperation<T>
                 //std::cout << "Transport: " << ((transport::TcpTransport*)transport)->getServerAddress().getPort() << std::endl;
             	transport::InetSocketAddress isa(te.getHostCString(),te.getPort());
             	failedServers.insert(isa);
-                transportFactory->invalidateTransport(isa, transport);
+                invalidateTransport(isa, transport);
                 logErrorAndThrowExceptionIfNeeded(retryCount, te);
             } catch (const RemoteNodeSuspectException& rnse) {
                 // Do not invalidate transport because this exception is caused
@@ -62,6 +62,12 @@ template<class T> class RetryOnFailureOperation : public HotRodOperation<T>
     virtual void releaseTransport(transport::Transport* transport) {
         if (transport) {
             transportFactory->releaseTransport(*transport);
+        }
+    }
+
+    virtual void invalidateTransport(const infinispan::hotrod::transport::InetSocketAddress & addr, transport::Transport* transport) {
+        if (transport) {
+            transportFactory->invalidateTransport(addr, transport);
         }
     }
 

--- a/src/hotrod/impl/transport/AbstractTransport.h
+++ b/src/hotrod/impl/transport/AbstractTransport.h
@@ -28,6 +28,7 @@ class AbstractTransport : public Transport
     int32_t read4ByteInt();
     std::string readString();
     TransportFactory& getTransportFactory();
+    virtual ~AbstractTransport() {}
 
   protected:
     virtual void writeBytes(const std::vector<char>& bytes) = 0;

--- a/src/hotrod/impl/transport/Transport.h
+++ b/src/hotrod/impl/transport/Transport.h
@@ -40,6 +40,8 @@ class Transport
 
     virtual bool targets(const InetSocketAddress&) const = 0;
     virtual Transport* clone() = 0;
+    virtual ~Transport() {}
+
 };
 
 }}} // namespace infinispan::hotrod::transport

--- a/src/hotrod/impl/transport/tcp/TcpTransport.cpp
+++ b/src/hotrod/impl/transport/tcp/TcpTransport.cpp
@@ -17,9 +17,16 @@ TcpTransport::TcpTransport(
     const InetSocketAddress& a, TransportFactory& factory)
 : AbstractTransport(factory), socket(sys::Socket::create()) {
     serverAddress.reset(new InetSocketAddress(a));
+    //try
+    //{
     socket.connect(a.getHostname(),a.getPort(), factory.getConnectTimeout());
     socket.setTimeout(factory.getSoTimeout());
     socket.setTcpNoDelay(factory.isTcpNoDelay());
+    //}
+    //catch (Exception& e) {
+    //    serverAddress.reset();
+    //    throw e;
+    //}
 }
 
 TcpTransport::TcpTransport(

--- a/src/hotrod/impl/transport/tcp/TcpTransportFactory.cpp
+++ b/src/hotrod/impl/transport/tcp/TcpTransportFactory.cpp
@@ -62,7 +62,14 @@ void TcpTransportFactory::start(
 
     balancer->setServers(initialServers);
     sniHostName = configuration.getSslConfiguration().sniHostName();
-    pingServers();
+    try
+    {
+        pingServers();
+    }
+    catch (Exception &e) {
+        delete topologyInfo;
+        throw e;
+    }
     this->listenerNotifier = listenerNotifier;
  }
 

--- a/src/hotrod/impl/transport/tcp/TcpTransportFactory.h
+++ b/src/hotrod/impl/transport/tcp/TcpTransportFactory.h
@@ -23,7 +23,7 @@ class InetSocketAddress;
 class TcpTransportFactory : public TransportFactory
 {
   public:
-    TcpTransportFactory(const Configuration& config) : configuration(config), maxRetries(config.getMaxRetries()) {};
+    TcpTransportFactory(const Configuration& config) : configuration(config), maxRetries(config.getMaxRetries()) {}
     void start(protocol::Codec& codec, int defaultTopologyId, ClientListenerNotifier* );
     void destroy();
 


### PR DESCRIPTION
This PR fixes some memleaks reported by the command:
valgrind nearCacheTest
some of them refer to the events framework.

Related jira is:
https://issues.jboss.org/browse/HRCPP-341