### PR TITLE
HRCPP-342 # Fixed memleaks on ssl test

### DIFF
--- a/test/QueryTest.cpp
+++ b/test/QueryTest.cpp
@@ -163,7 +163,7 @@ int main(int argc, char** argv) {
         std::cout << "result is: " << i << std::endl;
     }
 
-
+    cacheManager.stop();
     return result;
 }
 

--- a/test/SimpleTLS-SNI.cpp
+++ b/test/SimpleTLS-SNI.cpp
@@ -43,10 +43,12 @@ int test(const std::string &test_desc, int argc, char** argv, const std::string 
             std::unique_ptr < std::string > rv(cache.get(k1));
             if (rv->compare(v1)) {
                 std::cerr << "get/put fail for " << k1 << " got " << *rv << " expected " << v1 << std::endl;
+                cacheManager.stop();
                 return 1;
             }
             cacheManager.stop();
         } catch (Exception e) {
+            cacheManager.stop();
             return 1;
         }
     }


### PR DESCRIPTION
Added resources release to the connect() method. 
Fixes for https://issues.jboss.org/browse/HRCPP-342
