### PR TITLE
Hrcpp 347/close notify

### DIFF
--- a/src/hotrod/sys/SChannelSocket.h
+++ b/src/hotrod/sys/SChannelSocket.h
@@ -42,6 +42,7 @@ namespace infinispan {
 				DWORD           encryptSend(size_t len, SecPkgContext_StreamSizes Sizes);
 				SECURITY_STATUS clientHandshakeLoop(BOOL doInitialRead, SecBuffer  *pExtraData);
 				SECURITY_STATUS performClientHandshake(std::string host, SecBuffer  *pExtraData);
+                LONG DisconnectFromServer();
 				void            cleanup();
 
 				class SChannelInitializer

--- a/src/hotrod/sys/SSLSocket.cpp
+++ b/src/hotrod/sys/SSLSocket.cpp
@@ -99,6 +99,7 @@ void SSLSocket::write(const char *p, size_t n) {
 }
 
 void SSLSocket::close() {
+    SSL_shutdown(m_ssl);
     if(m_bio != 0)
         BIO_free_all(m_bio);
     if(m_ctx != 0)


### PR DESCRIPTION
Send close notify to peer in a SSL connection.

Fixes: https://issues.jboss.org/browse/HRCPP-347