### PR TITLE
HRCPP-348 Static Protobuf library is not found on Windows when

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,41 +278,28 @@ if(DEFINED HOTROD_PREBUILT_LIB_DIR)
             message(FATAL_ERROR "Cannot find HotRod Protobuf static library in directory '${HOTROD_PREBUILT_LIB_DIR}'.")
         else("${HOTROD_PROTOBUF_LIBRARY}" STREQUAL "HOTROD_PROTOBUF_LIBRARY-NOTFOUND")
             message("-- Found HotRod Protobuf static library: ${HOTROD_PROTOBUF_LIBRARY}")
-	  add_library(hotrod_protobuf STATIC IMPORTED GLOBAL)
+            add_library(hotrod_protobuf STATIC IMPORTED GLOBAL)
             set_target_properties(hotrod_protobuf PROPERTIES IMPORTED_LOCATION ${HOTROD_PROTOBUF_LIBRARY})
         endif("${HOTROD_PROTOBUF_LIBRARY}" STREQUAL "HOTROD_PROTOBUF_LIBRARY-NOTFOUND")
   
-        find_library(HR_PROTOBUF_LIBRARY NAMES libprotobuf.a protobuf.lib protobuf  PATHS ${HOTROD_PREBUILT_LIB_DIR}
+        find_library(HR_PROTOBUF_LIBRARY NAMES libprotobuf.a libprotobuf.lib protobuf  PATHS ${HOTROD_PREBUILT_LIB_DIR}
                 NO_SYSTEM_ENVIRONMENT_PATH NO_DEFAULT_PATH
                 NO_CMAKE_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_DEFAULT_PATH)
         if("${HR_PROTOBUF_LIBRARY}" STREQUAL "HR_PROTOBUF_LIBRARY-NOTFOUND")
             message(FATAL_ERROR "Cannot find protobuf static library in directory '${HOTROD_PREBUILT_LIB_DIR}'.")
         else("${HR_PROTOBUF_LIBRARY}" STREQUAL "HR_PROTOBUF_LIBRARY-NOTFOUND")
             message("-- Found Protobuf static library: ${HR_PROTOBUF_LIBRARY}")
-	    add_library(protobuf STATIC IMPORTED GLOBAL)
+            add_library(protobuf STATIC IMPORTED GLOBAL)
             set_target_properties(protobuf PROPERTIES IMPORTED_LOCATION ${HR_PROTOBUF_LIBRARY})
-	    set_target_properties(protobuf PROPERTIES IMPORTED_IMPLIB ${HR_PROTOBUF_LIBRARY})
+            set_target_properties(protobuf PROPERTIES IMPORTED_IMPLIB ${HR_PROTOBUF_LIBRARY})
             set(PROTOBUF_LIBRARY ${HR_PROTOBUF_LIBRARY})
         endif("${HR_PROTOBUF_LIBRARY}" STREQUAL "HR_PROTOBUF_LIBRARY-NOTFOUND")
-  
-        #find_library(HR_PROTOBUF_PROTOC_LIBRARY NAMES protoc libprotoc PATHS ${HOTROD_PREBUILT_LIB_DIR}
-        #        NO_SYSTEM_ENVIRONMENT_PATH NO_DEFAULT_PATH
-        #        NO_CMAKE_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_DEFAULT_PATH)
-        #if("${HR_PROTOBUF_PROTOC_LIBRARY}" STREQUAL "HR_PROTOBUF_PROTOC_LIBRARY-NOTFOUND")
-        #    message(FATAL_ERROR "Cannot find protoc library in directory '${HOTROD_PREBUILT_LIB_DIR}'.")
-        #else("${HR_PROTOBUF_PROTOC_LIBRARY}" STREQUAL "HR_PROTOBUF_PROTOC_LIBRARY-NOTFOUND")
-        #    message("-- Found Protoc static library: ${HR_PROTOBUF_PROTOC_LIBRARY}")
-	#    add_library(protoc STATIC IMPORTED GLOBAL)
-        #    set_target_properties(protoc PROPERTIES IMPORTED_LOCATION ${HR_PROTOBUF_PROTOC_LIBRARY})
-	#    set_target_properties(protoc PROPERTIES IMPORTED_IMPLIB ${HR_PROTOBUF_PROTOC_LIBRARY})
-        #    set(PROTOBUF_PROTOC_LIBRARY ${HR_PROTOBUF_PROTOC_LIBRARY})
-        #endif("${HR_PROTOBUF_PROTOC_LIBRARY}" STREQUAL "HR_PROTOBUF_PROTOC_LIBRARY-NOTFOUND")
 
-	if(NOT DEFINED WIN32)
+        if(NOT DEFINED WIN32)
             find_package(OpenSSL)
             include_directories(${OPENSSL_INCLUDE_DIR})
-    endif(NOT DEFINED WIN32)
-         
+         endif(NOT DEFINED WIN32)
+
         if(UNIX) 
             set (PROTOBUF_PROTOC_EXECUTABLE ${HOTROD_PREBUILT_LIB_DIR}/../bin/protoc)
         else(UNIX) 
@@ -437,7 +424,7 @@ if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set_target_properties(hotrod_protobuf PROPERTIES COMPILE_FLAGS "-fPIC ${WARNING_FLAGS}" )
 endif (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 target_include_directories(hotrod_protobuf PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
-	"${INCLUDE_FILES_DIR}"
+                                     "${INCLUDE_FILES_DIR}"
                                      "${CMAKE_CURRENT_BINARY_DIR}"
                                      "${PROTOBUF_INCLUDE_DIR}")
 
@@ -499,7 +486,7 @@ hr_protobuf_generate_cpp(TEST_PROTO_SRCS TEST_PROTO_HDRS
 
 add_executable (simple test/Simple.cpp)
 target_include_directories(simple PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
-	"${INCLUDE_FILES_DIR}"
+                                     "${INCLUDE_FILES_DIR}"
                                      "${CMAKE_CURRENT_BINARY_DIR}"
                                      "${PROTOBUF_INCLUDE_DIR}")
 set_property(TARGET simple PROPERTY CXX_STANDARD 11)
@@ -510,7 +497,7 @@ target_link_libraries (simple hotrod hotrod_protobuf ${PROTOBUF_LIBRARY} ${platf
 
 add_executable (simple-static test/Simple.cpp)
 target_include_directories(simple-static PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
-	"${INCLUDE_FILES_DIR}"
+                                     "${INCLUDE_FILES_DIR}"
                                      "${CMAKE_CURRENT_BINARY_DIR}"
                                      "${PROTOBUF_INCLUDE_DIR}")
 set_property(TARGET simple-static PROPERTY CXX_STANDARD 11)
@@ -521,8 +508,8 @@ target_link_libraries (simple-static hotrod-static hotrod_protobuf ${PROTOBUF_LI
 
 add_executable (queryTest test/QueryTest.cpp ${TEST_PROTO_SRCS})
 target_include_directories(queryTest PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
-	"${INCLUDE_FILES_DIR}"
-	"${INCLUDE_FILES_DIR}/infinispan/hotrod"
+                                     "${INCLUDE_FILES_DIR}"
+                                     "${INCLUDE_FILES_DIR}/infinispan/hotrod"
                                      "${CMAKE_CURRENT_BINARY_DIR}"
                                      "${PROTOBUF_INCLUDE_DIR}")
 set_property(TARGET queryTest PROPERTY CXX_STANDARD 11)
@@ -537,8 +524,8 @@ target_link_libraries (queryTest hotrod hotrod_protobuf  ${PROTOBUF_LIBRARY} ${p
 
 add_executable (queryTest-static ${TEST_PROTO_SRCS} test/QueryTest.cpp)
 target_include_directories(queryTest-static PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
-	"${INCLUDE_FILES_DIR}"
-	"${INCLUDE_FILES_DIR}/infinispan/hotrod"
+                                     "${INCLUDE_FILES_DIR}"
+                                     "${INCLUDE_FILES_DIR}/infinispan/hotrod"
                                      "${CMAKE_CURRENT_BINARY_DIR}"
                                      "${PROTOBUF_INCLUDE_DIR}")
 
@@ -554,7 +541,7 @@ target_link_libraries (queryTest-static hotrod-static hotrod_protobuf ${PROTOBUF
 
 add_executable (events test/Events.cpp)
 target_include_directories(events PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
-	"${INCLUDE_FILES_DIR}"
+                                     "${INCLUDE_FILES_DIR}"
                                      "${CMAKE_CURRENT_BINARY_DIR}"
                                      "${PROTOBUF_INCLUDE_DIR}")
 set_property(TARGET events PROPERTY CXX_STANDARD 11)
@@ -565,7 +552,7 @@ target_link_libraries (events hotrod hotrod_protobuf ${PROTOBUF_LIBRARY} ${platf
 
 add_executable (nearCacheTest test/NearCacheTest.cpp)
 target_include_directories(nearCacheTest PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
-	"${INCLUDE_FILES_DIR}"
+                                     "${INCLUDE_FILES_DIR}"
                                      "${CMAKE_CURRENT_BINARY_DIR}"
                                      "${PROTOBUF_INCLUDE_DIR}")
 set_property(TARGET nearCacheTest PROPERTY CXX_STANDARD 11)
@@ -576,8 +563,8 @@ target_link_libraries (nearCacheTest hotrod hotrod_protobuf ${PROTOBUF_LIBRARY} 
 
     add_executable (simple-tls test/SimpleTLS.cpp)
     target_include_directories(simple-tls PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
-	    "${INCLUDE_FILES_DIR}"
-	    "${INCLUDE_FILES_DIR}/infinispan/hotrod"
+                                         "${INCLUDE_FILES_DIR}"
+                                         "${INCLUDE_FILES_DIR}/infinispan/hotrod"
                                          "${CMAKE_CURRENT_BINARY_DIR}"
                                          "${PROTOBUF_INCLUDE_DIR}")
     set_property(TARGET simple-tls PROPERTY CXX_STANDARD 11)
@@ -587,8 +574,8 @@ target_link_libraries (nearCacheTest hotrod hotrod_protobuf ${PROTOBUF_LIBRARY} 
     target_link_libraries (simple-tls hotrod hotrod_protobuf ${PROTOBUF_LIBRARY} ${platform_libs} ${OPENSSL_LIBRARIES})
     add_executable (simple-tls-sni test/SimpleTLS-SNI.cpp)
     target_include_directories(simple-tls-sni PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
-	    "${INCLUDE_FILES_DIR}"
-	    "${INCLUDE_FILES_DIR}/infinispan/hotrod"
+                                         "${INCLUDE_FILES_DIR}"
+                                         "${INCLUDE_FILES_DIR}/infinispan/hotrod"
                                          "${CMAKE_CURRENT_BINARY_DIR}"
                                          "${PROTOBUF_INCLUDE_DIR}")
     set_property(TARGET simple-tls-sni PROPERTY CXX_STANDARD 11)
@@ -600,8 +587,8 @@ target_link_libraries (nearCacheTest hotrod hotrod_protobuf ${PROTOBUF_LIBRARY} 
 if (ENABLE_INTERNAL_TESTING)
     add_executable (unittest test/Unit.cpp)
 target_include_directories(unittest PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
-	"${INCLUDE_FILES_DIR}"
-	"${INCLUDE_FILES_DIR}/infinispan/hotrod"
+                                     "${INCLUDE_FILES_DIR}"
+                                     "${INCLUDE_FILES_DIR}/infinispan/hotrod"
                                      "${CMAKE_CURRENT_BINARY_DIR}"
                                      "${PROTOBUF_INCLUDE_DIR}")
     set_target_properties(unittest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}") 
@@ -610,8 +597,8 @@ target_include_directories(unittest PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/que
 
     add_executable (unittest-static test/Unit.cpp)
 target_include_directories(unittest-static PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
-	"${INCLUDE_FILES_DIR}"
-	"${INCLUDE_FILES_DIR}/infinispan/hotrod"
+                                     "${INCLUDE_FILES_DIR}"
+                                     "${INCLUDE_FILES_DIR}/infinispan/hotrod"
                                      "${CMAKE_CURRENT_BINARY_DIR}"
                                      "${PROTOBUF_INCLUDE_DIR}")
     set_target_properties(unittest-static PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
@@ -621,7 +608,7 @@ endif (ENABLE_INTERNAL_TESTING)
 
 add_executable (itest test/InteractiveTest.cpp)
 target_include_directories(itest PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
-	"${INCLUDE_FILES_DIR}"
+                                     "${INCLUDE_FILES_DIR}"
                                      "${CMAKE_CURRENT_BINARY_DIR}"
                                      "${PROTOBUF_INCLUDE_DIR}")
 target_include_directories(itest PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto")


### PR DESCRIPTION
HOTROD_PREBUILT_LIB_DIR is used

The main fix is on line 285. 
Also removed some tab characters in the file which accounts for the
other formatting changes.