### PR TITLE
HRCPP-366 # Fixed by processing ev response

### DIFF
--- a/src/hotrod/impl/operations/AddClientListenerOperation.cpp
+++ b/src/hotrod/impl/operations/AddClientListenerOperation.cpp
@@ -78,7 +78,11 @@ char AddClientListenerOperation::executeOperation(transport::Transport& transpor
 			{
 				uint8_t status = codec20.readPartialEventHeader(transport, params);
 				if (!HotRodConstants::isSuccess(status))
-					break;
+				{
+				    auto errLen = transport.readVInt();
+				    auto errMsg = transport.readBytes(errLen);
+				    throw HotRodClientException(std::string(errMsg.begin(), errMsg.end()));
+				}
 			}
 			catch (HotRodClientException e) {
 				continue;

--- a/src/hotrod/impl/transport/AbstractTransport.h
+++ b/src/hotrod/impl/transport/AbstractTransport.h
@@ -30,10 +30,6 @@ class AbstractTransport : public Transport
     TransportFactory& getTransportFactory();
     virtual ~AbstractTransport() {}
 
-  protected:
-    virtual void writeBytes(const std::vector<char>& bytes) = 0;
-    virtual std::vector<char> readBytes(uint32_t size) = 0;
-
   private:
     TransportFactory& transportFactory;
 };

--- a/src/hotrod/impl/transport/Transport.h
+++ b/src/hotrod/impl/transport/Transport.h
@@ -40,6 +40,10 @@ class Transport
 
     virtual bool targets(const InetSocketAddress&) const = 0;
     virtual Transport* clone() = 0;
+
+    virtual void writeBytes(const std::vector<char>& bytes) = 0;
+    virtual std::vector<char> readBytes(uint32_t size) = 0;
+
     virtual ~Transport() {}
 
 };


### PR DESCRIPTION
This PR contains the correct error handling for the AddClientListenerOperation.
When something goes wrong in the server the error is reported in an event error message (opcode 0x50), this is now processed.

Fix for: https://issues.jboss.org/browse/HRCPP-366