### PR TITLE
HRCPP-367 # fix plus code cleanup

### DIFF
--- a/src/hotrod/impl/event/ClientListenerNotifier.h
+++ b/src/hotrod/impl/event/ClientListenerNotifier.h
@@ -35,7 +35,7 @@ public:
 protected:
 	ClientListenerNotifier(std::shared_ptr<TransportFactory> factory);
 private:
-	std::map<std::vector<char>, EventDispatcher> eventDispatchers;
+	std::map<std::vector<char>, std::shared_ptr<EventDispatcher>> eventDispatchers;
 	std::shared_ptr<TransportFactory> transportFactory;
 };
 

--- a/src/hotrod/impl/event/EventDispatcher.cpp
+++ b/src/hotrod/impl/event/EventDispatcher.cpp
@@ -33,72 +33,56 @@ void EventDispatcher::stop()
 }
 
 void EventDispatcher::run() {
-	int retryCount = 0;
-	while (true) {
-		try {
-			while (1) {
-				EventHeaderParams params = codec20.readEventHeader(transport);
-				if (!(HotRodConstants::isEvent(params.opCode))) {
-					// TODO handle error in some way
-					break;
-				}
-				std::vector<char> listId = codec20.readEventListenerId(transport);
-				uint8_t isCustom = codec20.readEventIsCustomFlag(transport);
-				uint8_t isRetried = codec20.readEventIsRetriedFlag(transport);
-				if (isCustom != 0) {
-					ClientCacheEntryCustomEvent ev = codec20.readCustomEvent(
-							transport, isRetried);
-					cl.processEvent(ev, listId, isCustom);
-				} else {
-					switch (params.opCode) {
-					case HotRodConstants::CACHE_ENTRY_CREATED_EVENT_RESPONSE: {
-						ClientCacheEntryCreatedEvent<std::vector<char>> ev =
-								codec20.readCreatedEvent(transport, isRetried);
-						cl.processEvent(ev, listId, isCustom);
-					}
-						break;
-					case HotRodConstants::CACHE_ENTRY_MODIFIED_EVENT_RESPONSE: {
-						ClientCacheEntryModifiedEvent<std::vector<char>> ev =
-								codec20.readModifiedEvent(transport, isRetried);
-						cl.processEvent(ev, listId, isCustom);
-					}
-						break;
-					case HotRodConstants::CACHE_ENTRY_REMOVED_EVENT_RESPONSE: {
-						ClientCacheEntryRemovedEvent<std::vector<char>> ev =
-								codec20.readRemovedEvent(transport, isRetried);
-						cl.processEvent(ev, listId, isCustom);
-					}
-						break;
-                    case HotRodConstants::CACHE_ENTRY_EXPIRED_EVENT_RESPONSE: {
-                        if (codec20.getProtocolVersion() >= HotRodConstants::VERSION_21)
-                        { // ok codec has expired events
-                            ClientCacheEntryExpiredEvent<std::vector<char>> ev =
-                                    ((const Codec21&)codec20).readExpiredEvent(transport);
-                            cl.processEvent(ev, listId, isCustom);
-                        }
-                        else
-                        {
-                            ERROR("Received an Expired Entry Events but codec is %d<21",codec20.getProtocolVersion());
-                        }
+    while (true) {
+        try {
+            EventHeaderParams params = codec20.readEventHeader(transport);
+            if (!(HotRodConstants::isEvent(params.opCode))) {
+                // TODO handle error in some way
+                break;
+            }
+            std::vector<char> listId = codec20.readEventListenerId(transport);
+            uint8_t isCustom = codec20.readEventIsCustomFlag(transport);
+            uint8_t isRetried = codec20.readEventIsRetriedFlag(transport);
+            if (isCustom != 0) {
+                ClientCacheEntryCustomEvent ev = codec20.readCustomEvent(transport, isRetried);
+                cl.processEvent(ev, listId, isCustom);
+            } else {
+                switch (params.opCode) {
+                case HotRodConstants::CACHE_ENTRY_CREATED_EVENT_RESPONSE: {
+                    ClientCacheEntryCreatedEvent<std::vector<char>> ev = codec20.readCreatedEvent(transport, isRetried);
+                    cl.processEvent(ev, listId, isCustom);
+                }
+                    break;
+                case HotRodConstants::CACHE_ENTRY_MODIFIED_EVENT_RESPONSE: {
+                    ClientCacheEntryModifiedEvent<std::vector<char>> ev = codec20.readModifiedEvent(transport,
+                            isRetried);
+                    cl.processEvent(ev, listId, isCustom);
+                }
+                    break;
+                case HotRodConstants::CACHE_ENTRY_REMOVED_EVENT_RESPONSE: {
+                    ClientCacheEntryRemovedEvent<std::vector<char>> ev = codec20.readRemovedEvent(transport, isRetried);
+                    cl.processEvent(ev, listId, isCustom);
+                }
+                    break;
+                case HotRodConstants::CACHE_ENTRY_EXPIRED_EVENT_RESPONSE: {
+                    if (codec20.getProtocolVersion() >= HotRodConstants::VERSION_21) { // ok codec has expired events
+                        ClientCacheEntryExpiredEvent<std::vector<char>> ev =
+                                ((const Codec21&) codec20).readExpiredEvent(transport);
+                        cl.processEvent(ev, listId, isCustom);
+                    } else {
+                        ERROR("Received an Expired Entry Events but codec is %d<21", codec20.getProtocolVersion());
                     }
-                        break;
-					}
-				}
-			}
-		} catch (TransportException& ex) {
-
-			if (ex.getErrnum() == EINTR) {
-				// count a retry
-				bool b = dynamic_cast<TcpTransport&>(transport).isValid();
-				if (retryCount++ <= 1 && b)
-					continue;
-			}
-			if (recoveryCallback) {
-				recoveryCallback();
-			}
-			break;
-		}
-	}
+                }
+                    break;
+                }
+            }
+        } catch (TransportException& ex) {
+            if (recoveryCallback) {
+                recoveryCallback();
+            }
+            break;
+        }
+    }
 }
 } /* namespace event */
 } /* namespace hotrod */


### PR DESCRIPTION
changed code to cleanly release the event listener transport on listener remove and replaced mixed reference/pointer implementation with c++11 smart pointer.
Fixes: https://issues.jboss.org/browse/HRCPP-367