### PR TITLE
HRCPP-369 Changed CertFindCertificateInStore for win7

### DIFF
--- a/src/hotrod/sys/SChannelSocket.cpp
+++ b/src/hotrod/sys/SChannelSocket.cpp
@@ -643,7 +643,7 @@ void SChannelSocket::connect(const std::string & host, int port, int timeout)
         }
         
         pClientContext = CertFindCertificateInStore(certStore, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING
-            , 0, CERT_FIND_HAS_PRIVATE_KEY, NULL, NULL);
+            , 0, CERT_FIND_ANY, NULL, NULL);
         
 /*        pClientContext = CertCreateCertificateContext(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
             (BYTE*)derClientCert,


### PR DESCRIPTION
This PR changes the CertFindCertificateInStore call to be win7 compatible.
Fix for: https://issues.jboss.org/browse/HRCPP-369