### PR TITLE
HRCPP-371 Updated jar version and test

### DIFF
--- a/jni/pom.xml
+++ b/jni/pom.xml
@@ -17,8 +17,8 @@
    <description>Infinispan HotRod JNI Wrapper</description>
 
    <properties>
-      <version.org.infinispan>9.0.0.Alpha2</version.org.infinispan>
-      <version.org.jboss.logging.processor>1.1.0.Final</version.org.jboss.logging.processor>
+      <version.org.infinispan>9.0.0.Final</version.org.infinispan>
+      <version.org.jboss.logging.processor>1.2.1.Final</version.org.jboss.logging.processor>
       <version.org.jboss.jbossts>4.17.13.Final</version.org.jboss.jbossts>
       <version.org.testng>6.8</version.org.testng>
       <maven.test.skip.exec>true</maven.test.skip.exec>

--- a/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
+++ b/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
@@ -48,7 +48,6 @@ public class JniTest implements IMethodSelector {
             // CacheContainerTest.class,             // not relevant
             CacheManagerNotStartedTest.class, 
             CacheManagerStoppedTest.class, 
-            ClientAsymmetricClusterTest.class,       // HRCPP-120
             // ClientConnectionPoolingTest.class,    // requires transport extraction
             ClientSocketReadTimeoutTest.class,
             // omitting ConsistentHash* tests


### PR DESCRIPTION
This updates C++ jni testsuite to 9.0.0.Final.
ClientAsymmetricClusterTest.java is no more included.

Relates to: 
https://issues.jboss.org/browse/HRCPP-371