### PR TITLE
HRCPP-395 cast port to unsigned

### DIFF
--- a/src/hotrod/sys/posix/Socket.cpp
+++ b/src/hotrod/sys/posix/Socket.cpp
@@ -151,7 +151,7 @@ void Socket::connect(const std::string& h, int p, int timeout) {
 	struct addrinfo *addr_list;
 
 	host = h;
-	port = p;
+	port = (unsigned short)p;
 	if (fd != -1)
 		throwIOErr(host, port, "reconnect attempt", 0);
 


### PR DESCRIPTION
Cast tcp port to unsigned to prevent overflow.

Fixes: https://issues.jboss.org/browse/HRCPP-395