### PR TITLE
HRCPP-397 cast port to unsigned

### DIFF
--- a/src/hotrod/impl/transport/tcp/InetSocketAddress.cpp
+++ b/src/hotrod/impl/transport/tcp/InetSocketAddress.cpp
@@ -7,7 +7,7 @@ namespace infinispan {
 namespace hotrod {
 namespace transport {
 
-HR_EXPORT InetSocketAddress::InetSocketAddress(const std::string& host, int p): hostname(host), port(p) {
+HR_EXPORT InetSocketAddress::InetSocketAddress(const std::string& host, int p): hostname(host), port((unsigned short)p) {
     addresses = resolve(host, true);
 }
 


### PR DESCRIPTION
port field initializer needs to be cast to unsigned to prevent overflow

fix for https://issues.jboss.org/browse/HRCPP-397