### PR TITLE
HRCPP-398 Fix to catch randomic failure of manager.stop()

### DIFF
--- a/test/NearCacheTest.cpp
+++ b/test/NearCacheTest.cpp
@@ -65,9 +65,13 @@ int main(int argc, char** argv) {
     auto missesEnd = std::stoi(statsEnd["misses"]);
     std::cout << "Remote misses is: " << missesEnd-missesBegin << "" << std::endl;
     std::cout << "Remote hits is: " << hitsEnd-hitsBegin << "" << std::endl;
-    nearCacheManager.stop();
     }
     catch (Exception &e) {
+    }
+    try
+    {
         nearCacheManager.stop();
+    }
+    catch (Exception &e) {
     }
 }


### PR DESCRIPTION
fix for: 
https://issues.jboss.org/browse/HRCPP-398
