### PR TITLE
Hrcpp 390/rm some expected fail

### DIFF
--- a/jni/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -55,7 +55,8 @@ public class RemoteCacheManager /* implements BasicCacheContainer */{
 
     public RemoteCacheManager(Configuration config, boolean start) {
        jniRemoteCacheManager = new org.infinispan.client.hotrod.jni.RemoteCacheManager(config.getJniConfiguration(), start);
-       marshaller = new org.infinispan.commons.marshall.jboss.GenericJBossMarshaller();
+       marshaller = (config.marshaller()!=null) ? config.marshaller() :
+           new org.infinispan.commons.marshall.jboss.GenericJBossMarshaller();
     }
 
    public RemoteCacheManager(URL config, boolean start) throws IOException {

--- a/jni/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -78,19 +78,35 @@ public class RemoteCacheManager /* implements BasicCacheContainer */{
     }
     
     public <K, V> org.infinispan.client.hotrod.RemoteCache<K, V> getCache() {
-        return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, "", false);
+        try {
+			return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, "", false);
+		} catch (Exception e) {
+			return null;
+		}
     }
 
     public <K, V> org.infinispan.client.hotrod.RemoteCache<K, V> getCache(boolean forceReturnValue) {
-        return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, "", forceReturnValue);
+        try {
+			return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, "", forceReturnValue);
+		} catch (Exception e) {
+			return null;
+		}
     }
 
     public <K, V> org.infinispan.client.hotrod.RemoteCache<K, V> getCache(String cacheName) {
-        return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, cacheName, false);
+        try {
+			return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, cacheName, false);
+		} catch (Exception e) {
+			return null;
+		}
     }
 
     public <K, V> org.infinispan.client.hotrod.RemoteCache<K, V> getCache(String cacheName, boolean forceReturnValue) {
-        return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, cacheName, forceReturnValue);
+        try {
+			return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, cacheName, forceReturnValue);
+		} catch (Exception e) {
+			return null;
+		}
     }
 
     public Marshaller getMarshaller() {

--- a/jni/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -78,35 +78,35 @@ public class RemoteCacheManager /* implements BasicCacheContainer */{
     }
     
     public <K, V> org.infinispan.client.hotrod.RemoteCache<K, V> getCache() {
-        try {
-			return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, "", false);
-		} catch (Exception e) {
-			return null;
-		}
+       try {
+          return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, "", false);
+       } catch (Exception e) {
+          return null;
+       }
     }
 
     public <K, V> org.infinispan.client.hotrod.RemoteCache<K, V> getCache(boolean forceReturnValue) {
-        try {
-			return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, "", forceReturnValue);
-		} catch (Exception e) {
-			return null;
-		}
+       try {
+          return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, "", forceReturnValue);
+       } catch (Exception e) {
+          return null;
+       }
     }
 
     public <K, V> org.infinispan.client.hotrod.RemoteCache<K, V> getCache(String cacheName) {
-        try {
-			return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, cacheName, false);
-		} catch (Exception e) {
-			return null;
-		}
+       try {
+          return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, cacheName, false);
+       } catch (Exception e) {
+          return null;
+       }
     }
 
     public <K, V> org.infinispan.client.hotrod.RemoteCache<K, V> getCache(String cacheName, boolean forceReturnValue) {
-        try {
-			return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, cacheName, forceReturnValue);
-		} catch (Exception e) {
-			return null;
-		}
+       try {
+          return new org.infinispan.client.hotrod.impl.RemoteCacheImpl<K, V>(this, cacheName, forceReturnValue);
+       } catch (Exception e) {
+          return null;
+       }
     }
 
     public Marshaller getMarshaller() {

--- a/jni/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
@@ -60,8 +60,8 @@ public class Configuration {
       this.marshaller = marshaller2;
       this.servers = null;
       this.failoverServers = null;
-    this.transportFactory = null;
-	}
+      this.transportFactory = null;
+   }
 
    Configuration(ExecutorFactoryConfiguration asyncExecutorFactory, Class<? extends RequestBalancingStrategy> balancingStrategy, ClassLoader classLoader,
          ConnectionPoolConfiguration connectionPool, int connectionTimeout, Class<? extends ConsistentHash>[] consistentHashImpl, boolean forceReturnValues, int keySizeEstimate, Class<? extends Marshaller> marshallerClass,

--- a/jni/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
@@ -49,6 +49,20 @@ public class Configuration {
       this.transportFactory = null;
    }
 
+   public Configuration(org.infinispan.client.hotrod.jni.Configuration jniConfiguration, Marshaller marshaller2) {
+      super();
+      this.jniConfiguration = jniConfiguration;
+      this.asyncExecutorFactory = null;
+      this.balancingStrategy = null;
+      this.classLoader = null;
+      this.consistentHashImpl = null;
+      this.marshallerClass = (marshaller2==null) ? null : marshaller2.getClass();
+      this.marshaller = marshaller2;
+      this.servers = null;
+      this.failoverServers = null;
+    this.transportFactory = null;
+	}
+
    Configuration(ExecutorFactoryConfiguration asyncExecutorFactory, Class<? extends RequestBalancingStrategy> balancingStrategy, ClassLoader classLoader,
          ConnectionPoolConfiguration connectionPool, int connectionTimeout, Class<? extends ConsistentHash>[] consistentHashImpl, boolean forceReturnValues, int keySizeEstimate, Class<? extends Marshaller> marshallerClass,
          boolean pingOnStartup, String protocolVersion, List<ServerConfiguration> servers, List<ServerConfiguration> failOverServers, int socketTimeout, SslConfiguration ssl, boolean tcpNoDelay,

--- a/jni/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
@@ -178,9 +178,8 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<
 
    @Override
    public ConfigurationBuilder marshaller(Marshaller marshaller) {
-      throw new UnsupportedOperationException();
-//      this.marshaller = marshaller;
-//      return this;
+      this.marshaller = marshaller;
+      return this;
    }
 
    @Override
@@ -290,8 +289,9 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<
 
    @Override
    public Configuration build() {
-      return new Configuration(this.jniConfigurationBuilder.build());
-   }
+      return (marshaller != null) ? new Configuration(this.jniConfigurationBuilder.build(), marshaller)
+			: new Configuration(this.jniConfigurationBuilder.build(), marshaller);
+	   }
 
    public Configuration build(boolean validate) {
       if (validate) {

--- a/jni/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
+++ b/jni/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
@@ -69,11 +69,11 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<
 
    @Override
    public ServerConfigurationBuilder addServer() {
-	  return new ServerConfigurationBuilder(this,jniConfigurationBuilder.addServer());
+      return new ServerConfigurationBuilder(this,jniConfigurationBuilder.addServer());
    }
    
    public ClusterConfigurationBuilder addCluster(String clusterName) {
-	   return new ClusterConfigurationBuilder(this, jniConfigurationBuilder.addCluster(clusterName));	   
+      return new ClusterConfigurationBuilder(this, jniConfigurationBuilder.addCluster(clusterName));
    }
    
 
@@ -171,9 +171,8 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<
 
    @Override
    public ConfigurationBuilder marshaller(Class<? extends Marshaller> marshaller) {
-      throw new UnsupportedOperationException();
-//      this.marshallerClass = marshaller;
-//      return this;
+      this.marshallerClass = marshaller;
+      return this;
    }
 
    @Override
@@ -237,7 +236,7 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<
    
    @Override
    public ConfigurationBuilder maxRetries(int maxRetries) {
-	  this.jniConfigurationBuilder.maxRetries(maxRetries);
+      this.jniConfigurationBuilder.maxRetries(maxRetries);
       this.maxRetries = maxRetries;
       return this;
    }
@@ -290,8 +289,8 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<
    @Override
    public Configuration build() {
       return (marshaller != null) ? new Configuration(this.jniConfigurationBuilder.build(), marshaller)
-			: new Configuration(this.jniConfigurationBuilder.build(), marshaller);
-	   }
+                                  : new Configuration(this.jniConfigurationBuilder.build());
+   }
 
    public Configuration build(boolean validate) {
       if (validate) {

--- a/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
+++ b/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
@@ -90,12 +90,10 @@ public class JniTest implements IMethodSelector {
             "BulkGetKeysDistTest.testBulkGetAfterLifespanExpire",                // unstable, ISPN-4017
             "HotRodIntegrationTest.testReplaceWithVersionWithLifespanAsync",     // async not implemented
             "ClientSocketReadTimeoutTest.testPutTimeout",                        // TODO: TransportException not marshalled correctly
-            "RemoteCacheManagerTest.testMarshallerInstance",                     // setting marshaller through configuration builder not implemented
             "BulkGetKeysReplTest.testBulkGetAfterLifespanExpire",
             "BulkGetKeysSimpleTest.testBulkGetAfterLifespanExpire",
             "BulkGetReplTest.testBulkGetAfterLifespanExpire",
             "BulkGetSimpleTest.testBulkGetAfterLifespanExpire",
-            "ForceReturnValuesTest.testDifferentInstancesForDifferentForceReturnValues",
             "ForceReturnValuesTest.testSameInstanceForSameForceReturnValues",
             "HotRodIntegrationTest.testGetWithMetadata",
             "RemoteCacheManagerTest.testGetUndefinedCache"

--- a/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
+++ b/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
@@ -95,8 +95,7 @@ public class JniTest implements IMethodSelector {
             "BulkGetReplTest.testBulkGetAfterLifespanExpire",
             "BulkGetSimpleTest.testBulkGetAfterLifespanExpire",
             "ForceReturnValuesTest.testSameInstanceForSameForceReturnValues",
-            "HotRodIntegrationTest.testGetWithMetadata",
-            "RemoteCacheManagerTest.testGetUndefinedCache"
+            "HotRodIntegrationTest.testGetWithMetadata"
       ));
       Set<String> expectedSkips = Collections.emptySet();
 

--- a/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
+++ b/jni/src/test/java/org/infinispan/client/jni/hotrod/JniTest.java
@@ -14,22 +14,21 @@ import org.testng.IMethodSelectorContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.TestNG;
-import org.testng.reporters.TextReporter;
 
 public class JniTest implements IMethodSelector {
-	private final static String [] passOverTestList = {
-	"CacheManagerNotStartedTest.testPutAllAsync",
-	"CacheManagerNotStartedTest.testPutAsync",
-	"CacheManagerNotStartedTest.testReplaceAsync",
-	"CacheManagerNotStartedTest.testVersionedRemoveAsync",
-	"CacheManagerStoppedTest.testPutAllAsync",
-	"CacheManagerStoppedTest.testPutAsync",
-	"CacheManagerStoppedTest.testReplaceAsync",
-	"CacheManagerStoppedTest.testVersionedRemoveAsync",
+        private final static String [] passOverTestList = {
+        "CacheManagerNotStartedTest.testPutAllAsync",
+        "CacheManagerNotStartedTest.testPutAsync",
+        "CacheManagerNotStartedTest.testReplaceAsync",
+        "CacheManagerNotStartedTest.testVersionedRemoveAsync",
+        "CacheManagerStoppedTest.testPutAllAsync",
+        "CacheManagerStoppedTest.testPutAsync",
+        "CacheManagerStoppedTest.testReplaceAsync",
+        "CacheManagerStoppedTest.testVersionedRemoveAsync",
         "HotRodAsyncReplicationTest.testPutKeyValue"};
-	
+        
    private final static HashSet<String> passOverTestSet = new HashSet<String>(Arrays.asList(passOverTestList));
-	
+        
    public static void main(String[] args) {
       TestNG testng = new TestNG();
       testng.addMethodSelector("org.infinispan.client.jni.hotrod.JniTest", 1);
@@ -115,7 +114,7 @@ public class JniTest implements IMethodSelector {
       if (!unexpectedFails.isEmpty()) {
          exitCode = 1;
          System.err.println("These test fail (but should not!):");
-	 for (String testName : unexpectedFails) {
+      for (String testName : unexpectedFails) {
             System.err.println("\t" + testName);
          } 
       }
@@ -124,7 +123,7 @@ public class JniTest implements IMethodSelector {
       if (!notFailing.isEmpty()) {
          exitCode = 1;
          System.err.println("These test should fail (but don't!):");
-	 for (String testName : notFailing) {
+      for (String testName : notFailing) {
             System.err.println("\t" + testName);
          }
       }
@@ -133,7 +132,7 @@ public class JniTest implements IMethodSelector {
       if (!unexpectedSkips.isEmpty()) {
          exitCode = 1;
          System.err.println("These test have been skipped (but should not!):");
-	 for (String testName : unexpectedSkips) {
+      for (String testName : unexpectedSkips) {
             System.err.println("\t" + testName);
          } 
       }
@@ -142,7 +141,7 @@ public class JniTest implements IMethodSelector {
       if (!notSkipped.isEmpty()) {
          exitCode = 1;
          System.err.println("These test should have been skipped (but haven't!):");
-	 for (String testName : notSkipped) {
+         for (String testName : notSkipped) {
             System.err.println("\t" + testName);
          }
       }
@@ -153,20 +152,18 @@ public class JniTest implements IMethodSelector {
       System.exit(exitCode);
    }
 
-@Override
-public boolean includeMethod(IMethodSelectorContext context, ITestNGMethod method, boolean isTestMethod) {
-	String testName = method.getRealClass().getSimpleName()+"."+method.getMethodName();
-	if (passOverTestSet.contains(testName))
-	{
-		context.setStopped(true);
-		return false;
-	}
-	return true;
-}
+   @Override
+   public boolean includeMethod(IMethodSelectorContext context, ITestNGMethod method, boolean isTestMethod) {
+      String testName = method.getRealClass().getSimpleName()+"."+method.getMethodName();
+      if (passOverTestSet.contains(testName)) {
+         context.setStopped(true);
+         return false;
+      }
+      return true;
+   }
 
-@Override
-public void setTestMethods(List<ITestNGMethod> testMethods) {
-	// TODO Auto-generated method stub
-	
-}
+   @Override
+   public void setTestMethods(List<ITestNGMethod> testMethods) {
+        // TODO Auto-generated method stub
+   }
 }

--- a/src/hotrod/impl/RemoteCacheManagerImpl.cpp
+++ b/src/hotrod/impl/RemoteCacheManagerImpl.cpp
@@ -98,7 +98,8 @@ std::shared_ptr<RemoteCacheImpl> RemoteCacheManagerImpl::createRemoteCache(
     const std::string& name, bool forceReturnValue, NearCacheConfiguration nc)
 {
     ScopedLock<Mutex> l(lock);
-    std::map<std::string, RemoteCacheHolder>::iterator iter = cacheName2RemoteCache.find(name);
+    std::string nameAndForceFlag = (forceReturnValue) ? name+"/true" : name+"/false";
+    std::map<std::string, RemoteCacheHolder>::iterator iter = cacheName2RemoteCache.find(nameAndForceFlag);
     // Cache found
     if (iter != cacheName2RemoteCache.end()) {
         return iter->second.first;
@@ -123,7 +124,7 @@ std::shared_ptr<RemoteCacheImpl> RemoteCacheManagerImpl::createRemoteCache(
            }
         }
         // If ping on startup is disabled, or cache is defined in server
-        cacheName2RemoteCache[name] = RemoteCacheHolder(rcache_sptr, forceReturnValue);
+        cacheName2RemoteCache[nameAndForceFlag] = RemoteCacheHolder(rcache_sptr, forceReturnValue);
         return rcache_sptr;
     }
     catch (...)


### PR DESCRIPTION
This PR contains changes on the swig wrapper that remove some of expected failure in the java test list.
Plus a fix on the client that now correctly set the force return value flag in the request.

https://issues.jboss.org/browse/HRCPP-390