### PR TITLE
HRCPP-403 Remove near cache listener when cm stops

### DIFF
--- a/src/hotrod/impl/NearRemoteCacheImpl.h
+++ b/src/hotrod/impl/NearRemoteCacheImpl.h
@@ -170,6 +170,10 @@ private:
         this->addClientListener(cl, filterFactoryParams, converterFactoryParams,
                 failOverHandler);
     }
+    virtual void stop()
+    {
+        this->removeClientListener(cl);
+    }
 };
 
 }

--- a/src/hotrod/impl/RemoteCacheImpl.h
+++ b/src/hotrod/impl/RemoteCacheImpl.h
@@ -45,6 +45,7 @@ public:
     void addClientListener(ClientListener&, const std::vector<std::vector<char> >, const std::vector<std::vector<char> >, const std::function<void()> &);
     void removeClientListener(ClientListener&);
     virtual void init(operations::OperationsFactory* operationsFactory);
+    virtual void stop() {}
 
     void withFlags(Flag flag);
 

--- a/src/hotrod/impl/RemoteCacheManagerImpl.cpp
+++ b/src/hotrod/impl/RemoteCacheManagerImpl.cpp
@@ -61,9 +61,9 @@ void RemoteCacheManagerImpl::start() {
         listenerNotifier.reset(ClientListenerNotifier::create(transportFactory));
         transportFactory->start(*codec, defaultCacheTopologyId, listenerNotifier.get());
 
-       for(std::map<std::string, RemoteCacheHolder>::iterator iter = cacheName2RemoteCache.begin(); iter != cacheName2RemoteCache.end(); ++iter ) {
+        for(std::map<std::string, RemoteCacheHolder>::iterator iter = cacheName2RemoteCache.begin(); iter != cacheName2RemoteCache.end(); ++iter ) {
            startRemoteCache(*iter->second.first.get(), iter->second.second);
-       }
+        }
 
         started = true;
 	}
@@ -72,11 +72,14 @@ void RemoteCacheManagerImpl::start() {
 void RemoteCacheManagerImpl::stop() {
 	ScopedLock<Mutex> l(lock);
 	if (started) {
-        if  (listenerNotifier)
-            listenerNotifier->stop();
-        transportFactory->destroy();
-        started = false;
-    }
+		for (std::map<std::string, RemoteCacheHolder>::iterator iter = cacheName2RemoteCache.begin(); iter != cacheName2RemoteCache.end(); ++iter) {
+			stopRemoteCache(*iter->second.first.get());
+		}
+		if (listenerNotifier)
+			listenerNotifier->stop();
+		transportFactory->destroy();
+		started = false;
+	}
 }
 
 bool RemoteCacheManagerImpl::isStarted() {
@@ -141,6 +144,11 @@ void RemoteCacheManagerImpl::startRemoteCache(RemoteCacheImpl& remoteCache, bool
         *CodecFactory::getCodec(configuration.getProtocolVersionCString()));
 
     remoteCache.init(operationsFactory);
+
+}
+
+void RemoteCacheManagerImpl::stopRemoteCache(RemoteCacheImpl& remoteCache)
+{
 
 }
 

--- a/src/hotrod/impl/RemoteCacheManagerImpl.h
+++ b/src/hotrod/impl/RemoteCacheManagerImpl.h
@@ -50,6 +50,8 @@ class RemoteCacheManagerImpl
     std::shared_ptr<ClientListenerNotifier> listenerNotifier;
 
     void startRemoteCache(RemoteCacheImpl& remoteCache, bool forceReturnValue);
+    void stopRemoteCache(RemoteCacheImpl& remoteCache);
+
 };
 
 }} // namespace infinispan::hotrod


### PR DESCRIPTION
With this PR the client correctly remove all the listener for near cache when the cache manager is stopped.

https://issues.jboss.org/browse/HRCPP-403