### PR TITLE
HRCPP-429 Fixed Transport handling on error

### DIFF
--- a/src/hotrod/impl/RemoteCacheManagerImpl.cpp
+++ b/src/hotrod/impl/RemoteCacheManagerImpl.cpp
@@ -60,13 +60,11 @@ void RemoteCacheManagerImpl::start() {
         transportFactory.reset(TransportFactory::newInstance(configuration));
         listenerNotifier.reset(ClientListenerNotifier::create(transportFactory));
         transportFactory->start(*codec, defaultCacheTopologyId, listenerNotifier.get());
-
         for(std::map<std::string, RemoteCacheHolder>::iterator iter = cacheName2RemoteCache.begin(); iter != cacheName2RemoteCache.end(); ++iter ) {
            startRemoteCache(*iter->second.first.get(), iter->second.second);
         }
-
         started = true;
-	}
+    }
 }
 
 void RemoteCacheManagerImpl::stop() {
@@ -75,10 +73,10 @@ void RemoteCacheManagerImpl::stop() {
 		for (std::map<std::string, RemoteCacheHolder>::iterator iter = cacheName2RemoteCache.begin(); iter != cacheName2RemoteCache.end(); ++iter) {
 			stopRemoteCache(*iter->second.first.get());
 		}
-		if (listenerNotifier)
+        if (listenerNotifier)
 			listenerNotifier->stop();
-		transportFactory->destroy();
-		started = false;
+        transportFactory->destroy();
+        started = false;
 	}
 }
 

--- a/src/hotrod/impl/event/ClientListenerNotifier.cpp
+++ b/src/hotrod/impl/event/ClientListenerNotifier.cpp
@@ -65,10 +65,15 @@ void ClientListenerNotifier::stop()
 	}
 }
 
+void ClientListenerNotifier::releaseTransport(const std::vector<char> listenerId) {
+    eventDispatchers.find(listenerId)->second->getTransport().release();
+    eventDispatchers.find(listenerId)->second->waitThreadExit();
+    transportFactory->releaseTransport(eventDispatchers.find(listenerId)->second->getTransport());
+}
+
+
 void ClientListenerNotifier::removeClientListener(const std::vector<char> listenerId)
 {
-    eventDispatchers.find(listenerId)->second->getTransport().release();
-    transportFactory->releaseTransport(eventDispatchers.find(listenerId)->second->getTransport());
 	eventDispatchers.erase(listenerId);
 }
 

--- a/src/hotrod/impl/event/ClientListenerNotifier.h
+++ b/src/hotrod/impl/event/ClientListenerNotifier.h
@@ -31,6 +31,7 @@ public:
 	const Transport& findClientListenerTransport(const std::vector<char> listenerId);
 	static ClientListenerNotifier* create(std::shared_ptr<TransportFactory> factory);
 	void failoverClientListeners(const std::vector<transport::InetSocketAddress>& failedServers);
+	void releaseTransport(const std::vector<char> listenerId);
 	void stop();
 protected:
 	ClientListenerNotifier(std::shared_ptr<TransportFactory> factory);

--- a/src/hotrod/impl/event/EventDispatcher.cpp
+++ b/src/hotrod/impl/event/EventDispatcher.cpp
@@ -28,10 +28,21 @@ void EventDispatcher::start()
 
 void EventDispatcher::stop()
 {
-   // This terminates the thread
-   transport.release();
+    // This terminates the thread
+    transport.release();
+    waitThreadExit();
 }
 
+void EventDispatcher::waitThreadExit()
+{
+    if (p_thread)
+    {
+        if (p_thread->joinable())
+        {
+            p_thread->join();
+        }
+    }
+}
 void EventDispatcher::run() {
     while (true) {
         try {
@@ -76,7 +87,7 @@ void EventDispatcher::run() {
                     break;
                 }
             }
-        } catch (TransportException& ) {
+        } catch (const TransportException& ) {
             if (recoveryCallback) {
                 recoveryCallback();
             }

--- a/src/hotrod/impl/event/EventDispatcher.h
+++ b/src/hotrod/impl/event/EventDispatcher.h
@@ -32,33 +32,28 @@ template <class T> using X =  std::function<void(T)>;
 
 class EventDispatcher {
 public:
-	EventDispatcher(const std::vector<char> listenerId, const ClientListener& cl, std::vector<char> cacheName, Transport &t, const Codec20& codec20, std::shared_ptr<void> addClientListenerOpPtr, const std::function<void()> &recoveryCallback) : listenerId(listenerId), cl(cl), operationPtr(addClientListenerOpPtr), cacheName(cacheName), transport(t), codec20(codec20), recoveryCallback(recoveryCallback)
+    EventDispatcher(const std::vector<char> listenerId, const ClientListener& cl, std::vector<char> cacheName, Transport &t, const Codec20& codec20, std::shared_ptr<void> addClientListenerOpPtr, const std::function<void()> &recoveryCallback) : listenerId(listenerId), cl(cl), operationPtr(addClientListenerOpPtr), cacheName(cacheName), transport(t), codec20(codec20), recoveryCallback(recoveryCallback)
     {}
-	virtual ~EventDispatcher() {
-	    if (p_thread)
-	    {
-	        if (p_thread->joinable())
-	        {
-	            p_thread->join();
-	        }
-        }
-	}
-	Transport& getTransport() {
-		return transport;
-	}
+    virtual ~EventDispatcher() {
+        waitThreadExit();
+    }
+    Transport& getTransport() {
+        return transport;
+    }
     void run();
     void start();
     void stop();
-	const std::vector<char> listenerId;
-	const ClientListener& cl;
-	const std::shared_ptr<void> operationPtr;
+    void waitThreadExit();
+    const std::vector<char> listenerId;
+    const ClientListener& cl;
+    const std::shared_ptr<void> operationPtr;
 
 private:
-	std::vector<char> cacheName;
-	Transport &transport;
-	const Codec20& codec20;
-	std::shared_ptr<std::thread> p_thread;
-	const std::function<void()> &recoveryCallback;
+    std::vector<char> cacheName;
+    Transport &transport;
+    const Codec20& codec20;
+    std::shared_ptr<std::thread> p_thread;
+    const std::function<void()> &recoveryCallback;
 };
 
 } /* namespace event */

--- a/src/hotrod/impl/operations/AddClientListenerOperation.h
+++ b/src/hotrod/impl/operations/AddClientListenerOperation.h
@@ -38,7 +38,6 @@ public:
     virtual void releaseTransport(transport::Transport* transport);
     virtual void invalidateTransport(const infinispan::hotrod::transport::InetSocketAddress &, transport::Transport*);
 
-    virtual transport::Transport& getTransport(int retryCount, const std::set<transport::InetSocketAddress>& failedServers);
 	char executeOperation(transport::Transport& transport);
     ClientListenerNotifier& listenerNotifier;
 	const std::vector<char> listenerId;
@@ -53,6 +52,7 @@ private:
     std::vector<char> generateV4UUID();
 	void processEvent(const protocol::Codec20& codec20, uint8_t respOpCode,
 			transport::Transport& transport);
+	bool failed = false;
 
     /**
      * Dedicated transport instance for adding client listener. This transport

--- a/src/hotrod/impl/operations/RemoveClientListenerOperation.cpp
+++ b/src/hotrod/impl/operations/RemoveClientListenerOperation.cpp
@@ -32,6 +32,7 @@ char RemoveClientListenerOperation::executeOperation(transport::Transport& trans
     uint8_t status = readHeaderAndValidate(transport, *params);
     if (HotRodConstants::isSuccess(status))
     {
+      listenerNotifier.releaseTransport(clientListener.getListenerId());
       listenerNotifier.removeClientListener(clientListener.getListenerId());
     }
     return status;

--- a/src/hotrod/impl/transport/tcp/TcpTransport.cpp
+++ b/src/hotrod/impl/transport/tcp/TcpTransport.cpp
@@ -112,9 +112,9 @@ void TcpTransport::release() {
     try {
         socket.close();
     } catch (const Exception& e) {
-        socket.setValid(false);
         TRACE("Caught exception when closing socket: %s", e.what());
     }
+    socket.setValid(false);
 }
 
 void TcpTransport::destroy() {

--- a/test/ContinuousQueryTest.cpp
+++ b/test/ContinuousQueryTest.cpp
@@ -39,14 +39,12 @@ private:
     std::vector<std::function<void()> > cleanups;
 public:
     ~ResourceManager() {
-        while (cleanups.size() > 0)
-        {
+        while (cleanups.size() > 0) {
             cleanups.back()();
             cleanups.pop_back();
         }
     }
-    void add(std::function<void()> cleanup)
-    {
+    void add(std::function<void()> cleanup) {
         cleanups.push_back(cleanup);
     }
 };
@@ -64,31 +62,32 @@ int main(int argc, char** argv) {
     auto *km = new BasicTypesProtoStreamMarshaller<std::string>();
     auto *vm = new BasicTypesProtoStreamMarshaller<std::string>();
 
-    RemoteCache<std::string, std::string> metadataCache = cacheManager.getCache<std::string, std::string>(
-            km, &Marshaller<std::string>::destroy, vm, &Marshaller<std::string>::destroy, PROTOBUF_METADATA_CACHE_NAME,
+    RemoteCache<std::string, std::string> metadataCache = cacheManager.getCache<std::string, std::string>(km,
+            &Marshaller<std::string>::destroy, vm, &Marshaller<std::string>::destroy, PROTOBUF_METADATA_CACHE_NAME,
             false);
 
     ResourceManager rMain;
     cacheManager.start();
 
-    rMain.add([&cacheManager] { cacheManager.stop(); });
+    rMain.add([&cacheManager]
+    {   cacheManager.stop();});
 
     metadataCache.put("sample_bank_account/bank.proto", read("query_proto/bank.proto"));
-    if (metadataCache.containsKey(ERRORS_KEY_SUFFIX))
-    {
+    if (metadataCache.containsKey(ERRORS_KEY_SUFFIX)) {
         std::cerr << "fail: error in registering .proto model" << std::endl;
         result = -1;
         return result;
     }
-    rMain.add([&metadataCache] {
-             metadataCache.remove("sample_bank_account/bank.proto");
-         });
+    rMain.add([&metadataCache]
+    {
+        metadataCache.remove("sample_bank_account/bank.proto");
+    });
     auto *testkm = new BasicTypesProtoStreamMarshaller<int>();
     auto *testvm = new ProtoStreamMarshaller<sample_bank_account::User>();
     RemoteCache<int, sample_bank_account::User> testCache = cacheManager.getCache<int, sample_bank_account::User>(
-            testkm, &Marshaller<int>::destroy, testvm, &Marshaller<sample_bank_account::User>::destroy, "queryCache", false);
-    ContinuousQueryListener<int, sample_bank_account::User> cql(testCache,
-            "from sample_bank_account.User");
+            testkm, &Marshaller<int>::destroy, testvm, &Marshaller<sample_bank_account::User>::destroy, "queryCache",
+            false);
+    ContinuousQueryListener<int, sample_bank_account::User> cql(testCache, "from sample_bank_account.User");
     {
         ResourceManager r;
         std::cout << "Testing query: from sample_bank_account.User" << std::endl;
@@ -123,7 +122,8 @@ int main(int argc, char** argv) {
         cql.setLeavingListener(leave);
         cql.setUpdatedListener(change);
         testCache.addContinuousQueryListener(cql);
-        r.add([&testCache,&cql](){ testCache.removeContinuousQueryListener(cql);});
+        r.add([&testCache,&cql]()
+        {   testCache.removeContinuousQueryListener(cql);});
         sample_bank_account::User_Address a;
         sample_bank_account::User user1;
         user1.set_id(1);
@@ -148,24 +148,18 @@ int main(int argc, char** argv) {
 
         testCache.remove(2);
 
-        if (std::future_status::timeout
-                == promise.get_future().wait_for(std::chrono::seconds(30))) {
-            std::cout << "FAIL: Continuous query events (Timeout)" << std::endl;
-            return -1;
-        }
+        promise.get_future().wait();
 
         if (createdCount != 2 || changedCount != 1 || removedCount != 1) {
-            std::cout
-            << "FAIL: (createdCount,changedCount,removedCount) is  ("
-                    << createdCount << ", " << changedCount << ", "
-                    << removedCount << ")" << "  should be (2,1,1)"
-                    << std::endl;
+            std::cout << "FAIL: (createdCount,changedCount,removedCount) is  (" << createdCount << ", " << changedCount
+                    << ", " << removedCount << ")" << "  should be (2,1,1)" << std::endl;
             return -1;
         }
+        std::cout << "End Testing query: from sample_bank_account.User" << std::endl;
     }
-    
-    ContinuousQueryListener<int, sample_bank_account::User, int, std::string> cql1(
-            testCache, "select id, name from sample_bank_account.User");
+
+    ContinuousQueryListener<int, sample_bank_account::User, int, std::string> cql1(testCache,
+            "select id, name from sample_bank_account.User");
     {
         ResourceManager r;
         std::cout << "Testing query: select id, name from sample_bank_account.User" << std::endl;
@@ -201,30 +195,16 @@ int main(int argc, char** argv) {
         cql1.setLeavingListener(leave);
         cql1.setUpdatedListener(change);
 
-        std::vector<char> param;
-
-        std::string qString("select id, name from sample_bank_account.User");
-
-        BasicTypesProtoStreamMarshaller<std::string> paramMarshaller;
-
-        std::vector<std::vector<char>> filterFactoryParams;
-        paramMarshaller.marshall(qString, param);
-        filterFactoryParams.push_back(param);
-        std::vector<std::vector<char> > converterFactoryParams;
-        char CONTINUOUS_QUERY_FILTER_FACTORY_NAME[] =
-                "continuous-query-filter-converter-factory";
+        char CONTINUOUS_QUERY_FILTER_FACTORY_NAME[] = "continuous-query-filter-converter-factory";
         CacheClientListener<int, sample_bank_account::User> cl(testCache);
-        cl.filterFactoryName = std::vector<char>(
-                CONTINUOUS_QUERY_FILTER_FACTORY_NAME,
-                CONTINUOUS_QUERY_FILTER_FACTORY_NAME
-                        + strlen(CONTINUOUS_QUERY_FILTER_FACTORY_NAME));
-        cl.converterFactoryName = std::vector<char>(
-                CONTINUOUS_QUERY_FILTER_FACTORY_NAME,
-                CONTINUOUS_QUERY_FILTER_FACTORY_NAME
-                        + strlen(CONTINUOUS_QUERY_FILTER_FACTORY_NAME));
+        cl.filterFactoryName = std::vector<char>(CONTINUOUS_QUERY_FILTER_FACTORY_NAME,
+                CONTINUOUS_QUERY_FILTER_FACTORY_NAME + strlen(CONTINUOUS_QUERY_FILTER_FACTORY_NAME));
+        cl.converterFactoryName = std::vector<char>(CONTINUOUS_QUERY_FILTER_FACTORY_NAME,
+                CONTINUOUS_QUERY_FILTER_FACTORY_NAME + strlen(CONTINUOUS_QUERY_FILTER_FACTORY_NAME));
 
         testCache.addContinuousQueryListener(cql1);
-        r.add([&testCache,&cql1](){ testCache.removeContinuousQueryListener(cql1);});
+        r.add([&testCache,&cql1]()
+        {   testCache.removeContinuousQueryListener(cql1);});
 
         sample_bank_account::User_Address a;
         sample_bank_account::User user1;
@@ -250,25 +230,17 @@ int main(int argc, char** argv) {
 
         testCache.remove(3);
 
-        if (std::future_status::timeout
-                == promise.get_future().wait_for(std::chrono::seconds(30))) {
-            std::cout << "FAIL: Continuous query events (Timeout)"
-                    << std::endl;
-            return -1;
-        }
+        promise.get_future().wait();
 
         if (createdCount != 2 || changedCount != 1 || removedCount != 1) {
-            std::cout
-            << "FAIL: (createdCount, changedCount, removedCount) is  ("
-                    << createdCount << ", " << changedCount << ", "
-                    << removedCount << ")" << "  should be (2,1,1)"
-                    << std::endl;
+            std::cout << "FAIL: (createdCount, changedCount, removedCount) is  (" << createdCount << ", "
+                    << changedCount << ", " << removedCount << ")" << "  should be (2,1,1)" << std::endl;
             return -1;
         }
+        std::cout << "End Testing query: select id, name from sample_bank_account.User" << std::endl;
     }
 
-    ContinuousQueryListener<int, sample_bank_account::User> cql2(testCache,
-            "from sample_bank_account.User");
+    ContinuousQueryListener<int, sample_bank_account::User> cql2(testCache, "from sample_bank_account.User");
     ContinuousQueryListener<int, sample_bank_account::User> cql_where(testCache,
             "from sample_bank_account.User where name='Mickey'");
     {
@@ -294,7 +266,8 @@ int main(int argc, char** argv) {
                 {
                     std::cout << "LEAVING: key="<< u.id() << " value="<< u.name() << std::endl;
                     ++removedCount;
-                    if (k==1) {  // Removing 1 is the last operation
+                    if (k==1)
+                    {  // Removing 1 is the last operation
                         promise.set_value();
                     }
                 };
@@ -311,7 +284,8 @@ int main(int argc, char** argv) {
         cql2.setUpdatedListener(change);
 
         testCache.addContinuousQueryListener(cql2);
-        r.add([&testCache,&cql2](){ testCache.removeContinuousQueryListener(cql2);});
+        r.add([&testCache,&cql2]()
+        {   testCache.removeContinuousQueryListener(cql2);});
 
         int createdCount_where = 0, changedCount_where = 0, removedCount_where = 0;
 
@@ -341,7 +315,8 @@ int main(int argc, char** argv) {
         cql_where.setLeavingListener(leave_where);
         cql_where.setUpdatedListener(change_where);
         testCache.addContinuousQueryListener(cql_where);
-        r.add([&testCache,&cql_where](){ testCache.removeContinuousQueryListener(cql_where);});
+        r.add([&testCache,&cql_where]()
+        {   testCache.removeContinuousQueryListener(cql_where);});
 
         sample_bank_account::User_Address a;
         sample_bank_account::User user1;
@@ -371,35 +346,24 @@ int main(int argc, char** argv) {
 
         testCache.remove(1);  // threads sync. Removing 1 completes the promise
 
-        if (std::future_status::timeout
-                == promise.get_future().wait_for(std::chrono::seconds(30))) {
-            std::cout << "FAIL: Continuous query events (Timeout)" << std::endl;
-            return -1;
-        }
+        promise.get_future().wait();
 
-        if (std::future_status::timeout
-            == promise_where.get_future().wait_for(std::chrono::seconds(30))) {
-            std::cout << "FAIL: Continuous query events (Timeout-query-with-where)" << std::endl;
-            return -1;
-        }
+        promise_where.get_future().wait();
 
         if (createdCount != 2 || changedCount != 2 || removedCount != 2) {
-            std::cout
-            << "FAIL: (createdCount,changedCount,removedCount) is  ("
-                    << createdCount << ", " << changedCount << ", "
-                    << removedCount << ")" << "  should be (2,2,2)"
-                    << std::endl;
+            std::cout << "FAIL: (createdCount,changedCount,removedCount) is  (" << createdCount << ", " << changedCount
+                    << ", " << removedCount << ")" << "  should be (2,2,2)" << std::endl;
             return -1;
         }
 
         if (createdCount_where != 1 || changedCount_where != 1 || removedCount_where != 1) {
-            std::cout
-            << "FAIL: (createdCount_where,changedCount_where,removedCount_where) is  ("
-                    << createdCount_where << ", " << changedCount_where << ", "
-                    << removedCount_where << ")" << "  should be (1,1,1)"
+            std::cout << "FAIL: (createdCount_where,changedCount_where,removedCount_where) is  (" << createdCount_where
+                    << ", " << changedCount_where << ", " << removedCount_where << ")" << "  should be (1,1,1)"
                     << std::endl;
             return -1;
         }
+        std::cout << "End Testing multiple queries: from sample_bank_account.User" << std::endl;
+        std::cout << "                          from sample_bank_account.User where name='Mickey'" << std::endl;
     }
 
     std::cout << "PASS: continuous query" << std::endl;

--- a/xunit-test/NearCacheTest/NearCacheStaleReadsTest.cpp
+++ b/xunit-test/NearCacheTest/NearCacheStaleReadsTest.cpp
@@ -28,7 +28,7 @@ void Repeat(std::function<void(int, RemoteCache<std::string, std::string>&)> f)
     RemoteCache<std::string, std::string> cache = NearCacheStaleReadsTest::remoteCacheManager->getCache<std::string, std::string>(km1,
             &Marshaller<std::string>::destroy,
             vm1,
-            &Marshaller<std::string>::destroy, true);
+            &Marshaller<std::string>::destroy, false);
 
     cache.clear();
     cache.putIfAbsent("k", "v0");
@@ -63,9 +63,9 @@ TEST_F(NearCacheStaleReadsTest, AvoidStaleReadAfterPutRemoveTest) {
     std::function<void(int, RemoteCache<std::string, std::string>&)> f = [](int i, RemoteCache<std::string, std::string> &cache) {
     std::string value = std::string("v") + std::to_string(i);
     cache.put("k", value);
-    ASSERT_EQ(value, *cache.get("k"));
+    ASSERT_EQ(value, *cache.get("k")) << "Return value different from: " << value;
     cache.remove("k");
-    ASSERT_EQ(nullptr, cache.get("k"));
+    ASSERT_EQ(nullptr, cache.get("k")) << "Return value is not null";
 };
     Repeat(f);
 }


### PR DESCRIPTION
This PR fixes handling of the transport instance when an add listener operation fails. 
Also added fixes for some race condition in the near cache implementation

https://issues.jboss.org/browse/HRCPP-429
https://issues.jboss.org/browse/HRCPP-446