### PR TITLE
HRCPP-412 Added execute() method swig friendly

### DIFF
--- a/include/infinispan/hotrod/RemoteCache.h
+++ b/include/infinispan/hotrod/RemoteCache.h
@@ -777,6 +777,17 @@ template <class K, class V> class RemoteCache : private RemoteCacheBase
     }
 
     /**
+     * Execute script on server
+     * \param cmdName name of the script
+     * \param args maps of (name,value) arguments
+     * \return byte[] result in dark matter shape
+     */
+    std::vector<unsigned char> execute(const std::string& name, const std::map<std::vector<char>, std::vector<char> >& args)
+    {
+    	return base_execute(name,args);
+    }
+
+    /**
      * Execute a query on server
      * \param cmdName name of the script
      * \param args maps of (name,value) arguments

--- a/include/infinispan/hotrod/RemoteCacheBase.h
+++ b/include/infinispan/hotrod/RemoteCacheBase.h
@@ -64,6 +64,7 @@ protected:
     HR_EXTERN uint64_t  base_size();
     HR_EXTERN void  base_withFlags(Flag flag);
     HR_EXTERN std::vector<unsigned char> base_execute(const std::string &cmdName,  const std::map<std::string,std::string>& args);
+    HR_EXTERN std::vector<unsigned char> base_execute(const std::string &cmdName, const std::map<std::vector<char> ,std::vector<char> >& args);
     HR_EXTERN CacheTopologyInfo base_getCacheTopologyInfo();
     HR_EXTERN QueryResponse base_query(const QueryRequest &qr);
     HR_EXTERN std::vector<unsigned char> base_query_char(std::vector<unsigned char> qr, size_t size);

--- a/src/hotrod/api/RemoteCacheBase.cpp
+++ b/src/hotrod/api/RemoteCacheBase.cpp
@@ -137,6 +137,14 @@ std::vector<unsigned char> RemoteCacheBase::base_execute(const std::string &cmdN
 	return ures;
 }
 
+std::vector<unsigned char> RemoteCacheBase::base_execute(const std::string &cmdName, const std::map<std::vector<char> ,std::vector<char> >& args){
+        const std::vector<char> cmdNameBytes((cmdName.data()),(cmdName.data())+cmdName.size());
+	std::vector<char> resBytes= IMPL->execute(cmdNameBytes, args);
+
+	std::vector<unsigned char> ures(reinterpret_cast<unsigned char*>(resBytes.data()),reinterpret_cast<unsigned char*>(resBytes.data()+resBytes.size()));
+	return ures;
+}
+
 QueryResponse RemoteCacheBase::base_query(const QueryRequest &qr)
 {
 	return IMPL->query(qr);


### PR DESCRIPTION
Add a new execute() method that accept map of std::vector<char> key and value as arguments for the remote script.

https://issues.jboss.org/browse/HRCPP-412