### PR TITLE
HRCPP-435 Improved remote execute usability

### DIFF
--- a/include/infinispan/hotrod/JBasicMarshaller.h
+++ b/include/infinispan/hotrod/JBasicMarshaller.h
@@ -3,6 +3,7 @@
 
 
 #include <string>
+#include <cstring>
 #include <iostream>
 #include "infinispan/hotrod/Marshaller.h"
 #include "infinispan/hotrod/exceptions.h"
@@ -28,7 +29,7 @@ public:
     template <class T> static T unmarshall(char *);
 };
 
-    template <> std::string JBasicMarshallerHelper::unmarshall(char *b) {
+    template <> inline std::string JBasicMarshallerHelper::unmarshall(char *b) {
         if (b[0]!=JBasicMarshallerHelper::MARSHALL_VERSION)
             throw Exception("JBasicMarshallerHelper: bad version");
         if ( (b[1]!=JBasicMarshallerHelper::SMALL_STRING) && (b[1]!=JBasicMarshallerHelper::MEDIUM_STRING) )
@@ -36,7 +37,7 @@ public:
         return std::string(b+3,b[2]);
     }
 
-    template <> int JBasicMarshallerHelper::unmarshall(char *b) {
+    template <> inline int JBasicMarshallerHelper::unmarshall(char *b) {
         if (b[0]!=JBasicMarshallerHelper::MARSHALL_VERSION)
             throw Exception("JBasicMarshallerHelper: bad version");
         if (b[1]!=JBasicMarshallerHelper::INTEGER)

--- a/include/infinispan/hotrod/JBossMarshaller.h
+++ b/include/infinispan/hotrod/JBossMarshaller.h
@@ -1,0 +1,87 @@
+/*
+ * JBossMarshaller.h
+ *
+ *  Created on: Dec 4, 2017
+ *      Author: rigazilla
+ */
+
+#ifndef INCLUDE_INFINISPAN_HOTROD_JBOSSMARSHALLER_H_
+#define INCLUDE_INFINISPAN_HOTROD_JBOSSMARSHALLER_H_
+
+#include "infinispan/hotrod/JBasicMarshaller.h"
+
+namespace infinispan {
+namespace hotrod {
+
+class JBossMarshaller {
+public:
+    template<typename R> static R unmarshall(const std::vector<char>& b);
+    template<typename A> static std::vector<char> marshall(A a);
+    virtual ~JBossMarshaller() = 0;
+
+    static void marshallSmall(const std::string& s, std::vector<char>& b) {
+        b.resize(s.size() + 3);
+        char* buf = b.data();
+        // JBoss preamble
+        buf[0] = JBasicMarshallerHelper::MARSHALL_VERSION;
+        buf[1] = JBasicMarshallerHelper::SMALL_STRING;
+        buf[2] = (char) s.size();
+        memcpy(buf + 3, s.data(), s.size());
+    }
+    static void marshallMedium(const std::string& s, std::vector<char>& b) {
+        b.resize(s.size() + 4);
+        char* buf = b.data();
+        // JBoss preamble
+        buf[0] = JBasicMarshallerHelper::MARSHALL_VERSION;
+        buf[1] = JBasicMarshallerHelper::MEDIUM_STRING;
+        buf[2] = (char) (s.size() >> 8);
+        buf[3] = s.size() & 0xff;
+
+        memcpy(buf + 4, s.data(), s.size());
+    }
+
+};
+
+template<> inline int* JBossMarshaller::unmarshall(const std::vector<char>& b) {
+    int result = 0;
+    for (int i = 0; i < 4; i++) {
+        result <<= 8;
+        result ^= (int) *(b.data() + i + 2) & 0xFF;
+    }
+    int* s = new int(result);
+    return s;
+}
+
+template<> inline std::string* JBossMarshaller::unmarshall(const std::vector<char>& b) {
+    // TODO: this works only for SMALL_STRING
+    std::string* s = new std::string(b.begin() + 3, b.end() - 3);
+    return s;
+}
+
+template<> inline std::vector<char> JBossMarshaller::marshall(std::string s) {
+    std::vector<char> b;
+    if (s.size() <= 0x100) {
+        JBossMarshaller::marshallSmall(s, b);
+    } else {
+        JBossMarshaller::marshallMedium(s, b);
+    }
+    return b;
+}
+
+template<> inline std::vector<char> JBossMarshaller::marshall(int a) {
+    char buf[6];
+    std::vector<char> res;
+    // JBoss preamble
+    buf[0] = JBasicMarshallerHelper::MARSHALL_VERSION;
+    buf[1] = JBasicMarshallerHelper::INTEGER;
+    for (int i = 0; i < 4; i++) {
+        buf[5 - i] = (char) ((a) >> (8 * i));
+    }
+    res.assign(buf, buf + 6);
+    return res;
+}
+
+}
+}
+
+#endif /* INCLUDE_INFINISPAN_HOTROD_JBOSSMARSHALLER_H_ */

--- a/include/infinispan/hotrod/RemoteCache.h
+++ b/include/infinispan/hotrod/RemoteCache.h
@@ -13,7 +13,9 @@
 #include "infinispan/hotrod/Query.h"
 #include "infinispan/hotrod/QueryUtils.h"
 #include "infinispan/hotrod/ContinuousQueryListener.h"
-#include <infinispan/hotrod/BasicTypesProtoStreamMarshaller.h>
+#include "infinispan/hotrod/BasicTypesProtoStreamMarshaller.h"
+#include "infinispan/hotrod/JBossMarshaller.h"
+#include "infinispan/hotrod/RemoteExecution.h"
 #include <cmath>
 #include <set>
 #include <map>
@@ -28,6 +30,7 @@ namespace infinispan
 {
 namespace hotrod
 {
+
 /**
  * Provides remote reference to a cache residing on a Hot Rod server/cluster.
  *
@@ -99,6 +102,7 @@ private:
 #endif
 
 public:
+
     /**
      * Retrieves the name of the cache
      *
@@ -1097,6 +1101,18 @@ public:
         return *this;
     }
 
+    /**
+     * Get a remote execution context
+     *
+     * \return a RemoteExecution object that simplify the call of a remote execution task
+     *
+     */
+    template <class M = JBossMarshaller>
+    RemoteExecution<M> getRemoteExecution()
+    {
+        return RemoteExecution<M>(*this);
+    }
+
     RemoteCache(const RemoteCache &other) :
             RemoteCacheBase(other), keyMarshaller(other.keyMarshaller), valueMarshaller(other.valueMarshaller)
     {
@@ -1111,7 +1127,6 @@ public:
         setMarshallers(this, &keyMarshall, &valueMarshall, &keyUnmarshall, &valueUnmarshall);
         return *this;
     }
-
 protected:
     RemoteCache() :
             RemoteCacheBase()
@@ -1177,7 +1192,6 @@ private:
 
     friend class RemoteCacheManager;
 };
-
 }
 } // namespace
 

--- a/include/infinispan/hotrod/RemoteCacheBase.h
+++ b/include/infinispan/hotrod/RemoteCacheBase.h
@@ -65,12 +65,14 @@ protected:
     HR_EXTERN void  base_withFlags(Flag flag);
     HR_EXTERN std::vector<unsigned char> base_execute(const std::string &cmdName,  const std::map<std::string,std::string>& args);
     HR_EXTERN std::vector<unsigned char> base_execute(const std::string &cmdName, const std::map<std::vector<char> ,std::vector<char> >& args);
+    HR_EXTERN std::vector<char> base_execute(const std::vector<char> &cmdName, const std::map<std::vector<char> ,std::vector<char> >& args);
     HR_EXTERN CacheTopologyInfo base_getCacheTopologyInfo();
     HR_EXTERN QueryResponse base_query(const QueryRequest &qr);
     HR_EXTERN std::vector<unsigned char> base_query_char(std::vector<unsigned char> qr, size_t size);
 
 	HR_EXTERN void base_addClientListener(ClientListener &clientListener, const std::vector<std::vector<char> > filterFactoryParam, const std::vector<std::vector<char> > converterFactoryParams, const std::function<void()> &recoveryCallback);
 	HR_EXTERN void base_removeClientListener(ClientListener &clientListener);
+	HR_EXTERN void putScript(const std::vector<char>& name, const std::vector<char>& script);
 
     RemoteCacheBase() {}
     HR_EXTERN void setMarshallers(void* rc, MarshallHelperFn kf, MarshallHelperFn vf, UnmarshallHelperFn ukf, UnmarshallHelperFn uvf);
@@ -197,6 +199,8 @@ friend class ::infinispan::hotrod::event::CacheClientListener;
 #ifndef SWIGCSHARP
 template <typename... Params>
 friend class ::infinispan::hotrod::event::ContinuousQueryListener;
+template <class M> friend class RemoteExecution;
+
 #endif
 };
 

--- a/include/infinispan/hotrod/RemoteExecution.h
+++ b/include/infinispan/hotrod/RemoteExecution.h
@@ -1,0 +1,83 @@
+/*
+ * RemoteExecution.h
+ *
+ *  Created on: Dec 5, 2017
+ *      Author: rigazilla
+ */
+
+#ifndef INCLUDE_INFINISPAN_HOTROD_REMOTEEXECUTION_H_
+#define INCLUDE_INFINISPAN_HOTROD_REMOTEEXECUTION_H_
+
+#include "infinispan/hotrod/ImportExport.h"
+#include "infinispan/hotrod/JBossMarshaller.h"
+#include "infinispan/hotrod/RemoteCacheBase.h"
+
+namespace infinispan {
+namespace hotrod {
+
+/**
+ * Simplify and improve the call of a remote execution task:
+ *  - no more direct (un)marshalling is needed
+ *  - args value can be of differents type
+ *  - return value is statically typed
+ *  - no need to explicitly open the __script_cache cache
+ *
+ *  A Marshaller must be provided as template arguments. JBossMarshaller
+ *  can be used as reference.
+ */
+template<class M = JBossMarshaller>
+class RemoteExecution {
+public:
+    RemoteExecution(RemoteCacheBase& cache) :
+            cache(cache) {
+    }
+
+    /**
+     * Execute a remote task
+     *
+     * \param s name of the script to invlke
+     * \return the result of the execution
+     * \tparam ResultType the type of the result value
+     */
+    template<typename ResultType>
+    ResultType execute(const std::string& s) {
+        std::vector<char> buff(s.begin(), s.end());
+        return M::template unmarshall<ResultType>(cache.base_execute(buff, m));
+    }
+
+    /**
+     * Add a name,value pair to the arguments list
+     *
+     * \param s name of the arg
+     * \param v value of the arg
+     * \tparam ArgType is the type of the arg value. It can be of any type
+     * as long as the Marshaller is equipped with the related implementation
+     */
+    template<typename ArgType>
+    void addArg(std::string s, ArgType v) {
+        std::vector<char> buffK(s.begin(), s.end());
+        std::vector<char> buffV(M::marshall(v));
+        m[buffK] = buffV;
+    }
+
+    /**
+     * Install a script on the server
+     *
+     * \param name the name of the script
+     * \param script the code
+     */
+    void putScript(const std::string& name, const std::string& script) {
+        std::vector<char> buffName(M::marshall(name));
+        std::vector<char> buffScript(M::marshall(script));
+        cache.putScript(buffName, buffScript);
+    }
+
+private:
+    std::map<std::vector<char>, std::vector<char>> m;
+    RemoteCacheBase& cache;
+};
+
+}
+}
+
+#endif /* INCLUDE_INFINISPAN_HOTROD_REMOTEEXECUTION_H_ */

--- a/jni/src/main/swig/java.i
+++ b/jni/src/main/swig/java.i
@@ -158,9 +158,10 @@ using namespace infinispan::hotrod;
 %ignore RelayBytes::getBytes;
 %ignore RelayBytes::getJarray;
 %ignore goAsync;
+%ignore JBossMarshaller;
+%ignore addExecuteArg;
+%ignore putExecuteScript;
 %ignore addContinuousQueryListener;
-
-//%shared_ptr(RelayShrPointer)
 
 %inline %{
 

--- a/src/hotrod/api/RemoteCacheBase.cpp
+++ b/src/hotrod/api/RemoteCacheBase.cpp
@@ -4,7 +4,9 @@
 #include "infinispan/hotrod/RemoteCacheManager.h"
 #include "hotrod/impl/RemoteCacheImpl.h"
 #include "infinispan/hotrod/Query.h"
+#include "../impl/RemoteCacheManagerImpl.h"
 #include <iostream>
+#include <memory>
 
 namespace infinispan {
 namespace hotrod {
@@ -145,6 +147,10 @@ std::vector<unsigned char> RemoteCacheBase::base_execute(const std::string &cmdN
 	return ures;
 }
 
+std::vector<char> RemoteCacheBase::base_execute(const std::vector<char> &cmdName, const std::map<std::vector<char> ,std::vector<char> >& args){
+    return IMPL->execute(cmdName, args);
+}
+
 QueryResponse RemoteCacheBase::base_query(const QueryRequest &qr)
 {
 	return IMPL->query(qr);
@@ -181,6 +187,13 @@ void RemoteCacheBase::base_removeClientListener(ClientListener& clientListener)
 {
 	IMPL->removeClientListener(clientListener);
 }
+
+void RemoteCacheBase::putScript(const std::vector<char>& name, const std::vector<char>& script) {
+    shared_ptr<RemoteCacheImpl> rcImpl = this->impl->remoteCacheManager.createRemoteCache("___script_cache", false,
+            NearCacheConfiguration());
+    rcImpl->putraw(name, script, 0, 0);
+}
+
 }
 } /* namespace */
 

--- a/src/hotrod/impl/RemoteCacheImpl.cpp
+++ b/src/hotrod/impl/RemoteCacheImpl.cpp
@@ -73,6 +73,13 @@ std::map<std::vector<char>,std::vector<char>> RemoteCacheImpl::getAll(const std:
     return result;
 }
 
+std::vector<char> RemoteCacheImpl::putraw(const std::vector<char> &k, const std::vector<char> &v, uint64_t life, uint64_t idle) {
+    assertRemoteCacheManagerIsStarted();
+    applyDefaultExpirationFlags(life, idle);
+    std::unique_ptr<PutOperation> op(operationsFactory->newPutKeyValueOperation(k, v,life,idle));
+    return op->execute();
+}
+
 void *RemoteCacheImpl::put(RemoteCacheBase& remoteCacheBase, const void *k, const void* v, uint64_t life, uint64_t idle) {
 	assertRemoteCacheManagerIsStarted();
 	std::vector<char> kbuf, vbuf;

--- a/src/hotrod/impl/RemoteCacheImpl.h
+++ b/src/hotrod/impl/RemoteCacheImpl.h
@@ -25,6 +25,7 @@ public:
     virtual void *get(RemoteCacheBase& rcb, const void* key);
     std::map<std::vector<char>,std::vector<char>> getAll(const std::set<std::vector<char>>& keySet);
     virtual void *put(RemoteCacheBase& rcb, const void *key, const void* val, uint64_t life, uint64_t idle);
+    std::vector<char> putraw(const std::vector<char> &k, const std::vector<char> &v, uint64_t life, uint64_t idle);
     void *putIfAbsent(RemoteCacheBase& rcb, const void *key, const void* val, uint64_t life, uint64_t idle);
     virtual void *replace(RemoteCacheBase& rcb, const void *key, const void* val, uint64_t life, uint64_t idle);
     virtual void *remove(RemoteCacheBase& rcb, const void* key);
@@ -59,6 +60,8 @@ private:
 
     void applyDefaultExpirationFlags(uint64_t lifespan, uint64_t maxIdle);
     void assertRemoteCacheManagerIsStarted();
+    friend void RemoteCacheBase::putScript(const std::vector<char>& name, const std::vector<char>& script);
+
 };
 
 class KeyUnmarshallerFtor {


### PR DESCRIPTION
Improvement of the remote execute interface. Now user can pass arguments and call remote execution without having to directly deal with marshaller.
https://issues.jboss.org/browse/HRCPP-435

Example:

`

            std::string script("// mode=local, language=javascript, parameters=[keyValue, keyName, num]\n"
                    "var cache = cacheManager.getCache(\"namedCache\");\n"
                    "cache.put(\"a\", keyValue);\n"
                    "cache.put(\"b\", \"b\");\n"
                    "cache.get(keyName);\n"
                    "num;\n");
            RemoteExecution<> execution = cache.getRemoteExecution();
            execution.putScript("script.js", script);
            execution.addArg("keyValue", "abc");
            execution.addArg("keyName", "a");
            execution.addArg("num", 2);

            int* ret = execution.template execute<int*>("script.js");
`
