### PR TITLE
Hrcpp 436/new cmake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,14 +287,21 @@ if(DEFINED HOTROD_PREBUILT_LIB_DIR)
 
     # Find protobuf libraries looking only into the distro pack
     if(DEFINED HR_USE_SYSTEM_PROTOBUF)
-        # look into the system defaults
-        find_library(HR_PROTOBUF_LIBRARY NAMES libprotobuf.a libprotobuf.lib libprotobuf-static.lib protobuf)
+        find_package(Protobuf REQUIRED)
+        set(HR_PROTOBUF_LIBRARY ${PROTOBUF_LIBRARY})
     else(DEFINED HR_USE_SYSTEM_PROTOBUF)
+        #FIND protoc executable
+        if(UNIX)
+            set (PROTOBUF_PROTOC_EXECUTABLE ${HOTROD_PREBUILT_LIB_DIR}/../bin/protoc)
+        else(UNIX)
+            set (PROTOBUF_PROTOC_EXECUTABLE ${HOTROD_PREBUILT_LIB_DIR}/../bin/protoc.exe)
+        endif(UNIX)
         # look only into the distro pack
         find_library(HR_PROTOBUF_LIBRARY NAMES libprotobuf.a libprotobuf.lib libprotobuf-static.lib protobuf  PATHS ${HOTROD_PREBUILT_LIB_DIR}
             NO_SYSTEM_ENVIRONMENT_PATH NO_DEFAULT_PATH
             NO_CMAKE_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_DEFAULT_PATH)
     endif(DEFINED HR_USE_SYSTEM_PROTOBUF)
+    message("-- Found protoc executable: ${PROTOBUF_PROTOC_EXECUTABLE}")
     if("${HR_PROTOBUF_LIBRARY}" STREQUAL "HR_PROTOBUF_LIBRARY-NOTFOUND")
         message(FATAL_ERROR "Cannot find protobuf static library in directory '${HOTROD_PREBUILT_LIB_DIR}'.")
     else("${HR_PROTOBUF_LIBRARY}" STREQUAL "HR_PROTOBUF_LIBRARY-NOTFOUND")
@@ -312,12 +319,6 @@ if(DEFINED HOTROD_PREBUILT_LIB_DIR)
     endif(NOT DEFINED WIN32)
 
 
-    #FIND protoc executable
-    if(UNIX)
-        set (PROTOBUF_PROTOC_EXECUTABLE ${HOTROD_PREBUILT_LIB_DIR}/../bin/protoc)
-    else(UNIX)
-        set (PROTOBUF_PROTOC_EXECUTABLE ${HOTROD_PREBUILT_LIB_DIR}/../bin/protoc.exe)
-    endif(UNIX)
     set (PROTOBUF_INCLUDE_DIR ${HOTROD_PREBUILT_LIB_DIR}/../include)
 else(DEFINED HOTROD_PREBUILT_LIB_DIR)
     find_package(Protobuf REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,10 +288,10 @@ if(DEFINED HOTROD_PREBUILT_LIB_DIR)
     # Find protobuf libraries looking only into the distro pack
     if(DEFINED HR_USE_SYSTEM_PROTOBUF)
         # look into the system defaults
-        find_library(HR_PROTOBUF_LIBRARY NAMES libprotobuf.a libprotobuf.lib protobuf)
+        find_library(HR_PROTOBUF_LIBRARY NAMES libprotobuf.a libprotobuf.lib libprotobuf-static.lib protobuf)
     else(DEFINED HR_USE_SYSTEM_PROTOBUF)
         # look only into the distro pack
-        find_library(HR_PROTOBUF_LIBRARY NAMES libprotobuf.a libprotobuf.lib protobuf  PATHS ${HOTROD_PREBUILT_LIB_DIR}
+        find_library(HR_PROTOBUF_LIBRARY NAMES libprotobuf.a libprotobuf.lib libprotobuf-static.lib protobuf  PATHS ${HOTROD_PREBUILT_LIB_DIR}
             NO_SYSTEM_ENVIRONMENT_PATH NO_DEFAULT_PATH
             NO_CMAKE_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_DEFAULT_PATH)
     endif(DEFINED HR_USE_SYSTEM_PROTOBUF)
@@ -320,46 +320,45 @@ if(DEFINED HOTROD_PREBUILT_LIB_DIR)
     endif(UNIX)
     set (PROTOBUF_INCLUDE_DIR ${HOTROD_PREBUILT_LIB_DIR}/../include)
 else(DEFINED HOTROD_PREBUILT_LIB_DIR)
+    find_package(Protobuf REQUIRED)
 
-find_package(Protobuf REQUIRED)
-
-# OpenSSL support
-if(NOT DEFINED WIN32)
-    find_package(OpenSSL)
-    include_directories(${OPENSSL_INCLUDE_DIR})
-endif(NOT DEFINED WIN32)
-include_directories ("${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/src" "${CMAKE_CURRENT_BINARY_DIR}")
-set (INCLUDE_FILES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+    # OpenSSL support
+    if(NOT DEFINED WIN32)
+        find_package(OpenSSL)
+        include_directories(${OPENSSL_INCLUDE_DIR})
+    endif(NOT DEFINED WIN32)
+    include_directories ("${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/src" "${CMAKE_CURRENT_BINARY_DIR}")
+    set (INCLUDE_FILES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 
-# Select driver
-if(HOTROD_WINAPI)
-  set (platform_sources src/hotrod/sys/windows/Socket.cpp src/hotrod/sys/windows/Thread.cpp
-           src/hotrod/sys/windows/platform.cpp src/hotrod/sys/windows/Inet.cpp src/hotrod/sys/windows/Time.cpp)
-else(HOTROD_WINAPI)
-  set (platform_sources src/hotrod/sys/posix/Socket.cpp src/hotrod/sys/posix/Thread.cpp
-           src/hotrod/sys/posix/platform.cpp src/hotrod/sys/posix/Mutex.cpp src/hotrod/sys/posix/Inet.cpp src/hotrod/sys/posix/Time.cpp)
-endif(HOTROD_WINAPI)
+    # Select driver
+    if(HOTROD_WINAPI)
+      set (platform_sources src/hotrod/sys/windows/Socket.cpp src/hotrod/sys/windows/Thread.cpp
+               src/hotrod/sys/windows/platform.cpp src/hotrod/sys/windows/Inet.cpp src/hotrod/sys/windows/Time.cpp)
+    else(HOTROD_WINAPI)
+      set (platform_sources src/hotrod/sys/posix/Socket.cpp src/hotrod/sys/posix/Thread.cpp
+               src/hotrod/sys/posix/platform.cpp src/hotrod/sys/posix/Mutex.cpp src/hotrod/sys/posix/Inet.cpp src/hotrod/sys/posix/Time.cpp)
+    endif(HOTROD_WINAPI)
 
-if(ENABLE_INTERNAL_TESTING)
-set (internal_test_sources
-  src/hotrod/test/Unit.cpp
-  src/hotrod/test/L3Test.cpp
-  src/hotrod/test/HashTest.cpp
-  src/hotrod/test/ConnectionPoolTest.cpp
-)
-if(WIN32)
-set (socket_impl
-      src/hotrod/impl/transport/tcp/SChannelTcpTransport.cpp
-      src/hotrod/sys/SChannelSocket.cpp
-      )
-else(WIN32)
-set (socket_impl
-      src/hotrod/impl/transport/tcp/SSLTcpTransport.cpp
-      src/hotrod/sys/SSLSocket.cpp
-      )
-endif(WIN32)
-endif(ENABLE_INTERNAL_TESTING)
+    if(ENABLE_INTERNAL_TESTING)
+    set (internal_test_sources
+      src/hotrod/test/Unit.cpp
+      src/hotrod/test/L3Test.cpp
+      src/hotrod/test/HashTest.cpp
+      src/hotrod/test/ConnectionPoolTest.cpp
+    )
+    if(WIN32)
+    set (socket_impl
+          src/hotrod/impl/transport/tcp/SChannelTcpTransport.cpp
+          src/hotrod/sys/SChannelSocket.cpp
+          )
+    else(WIN32)
+    set (socket_impl
+          src/hotrod/impl/transport/tcp/SSLTcpTransport.cpp
+          src/hotrod/sys/SSLSocket.cpp
+          )
+    endif(WIN32)
+    endif(ENABLE_INTERNAL_TESTING)
 
     set (library_sources
       src/hotrod/api/RemoteCacheManager.cpp
@@ -427,28 +426,28 @@ endif(ENABLE_INTERNAL_TESTING)
       ${internal_test_sources}  
       ${CMAKE_BINARY_DIR}/Version.cpp
     )
-hr_protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS infinispan/hotrod
-  proto/infinispan/hotrod/protobuf/base_types.proto
-  proto/org/infinispan/protostream/message-wrapping.proto
-  proto/org/infinispan/query/remote/client/query.proto
-)
+    hr_protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS infinispan/hotrod
+      proto/infinispan/hotrod/protobuf/base_types.proto
+      proto/org/infinispan/protostream/message-wrapping.proto
+      proto/org/infinispan/query/remote/client/query.proto
+    )
 
-include_directories(${PROTOBUF_INCLUDE_DIR})
+    include_directories(${PROTOBUF_INCLUDE_DIR})
     
     add_library (hotrod_protobuf STATIC ${PROTO_SRCS})
     set_target_properties(hotrod_protobuf PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
-if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set_target_properties(hotrod_protobuf PROPERTIES COMPILE_FLAGS "-fPIC ${WARNING_FLAGS}" )
-endif (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-target_include_directories(hotrod_protobuf PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
+    if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set_target_properties(hotrod_protobuf PROPERTIES COMPILE_FLAGS "-fPIC ${WARNING_FLAGS}" )
+    endif (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_include_directories(hotrod_protobuf PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
                                      "${INCLUDE_FILES_DIR}"
                                      "${CMAKE_CURRENT_BINARY_DIR}"
                                      "${PROTOBUF_INCLUDE_DIR}")
 
-configure_file(src/hotrod/impl/Version.cpp.in ${CMAKE_BINARY_DIR}/Version.cpp @ONLY)
-if (MSVC)
-    set_target_properties(hotrod_protobuf PROPERTIES COMPILE_FLAGS "/wd4244 /wd4267" )
-endif (MSVC)
+    configure_file(src/hotrod/impl/Version.cpp.in ${CMAKE_BINARY_DIR}/Version.cpp @ONLY)
+    if (MSVC)
+        set_target_properties(hotrod_protobuf PROPERTIES COMPILE_FLAGS "/wd4244 /wd4267" )
+    endif (MSVC)
     
     # Build a shared library
     add_library (hotrod SHARED ${library_sources})
@@ -474,8 +473,8 @@ endif (MSVC)
     set_target_properties(hotrod-static PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS} ${STATIC_FLAGS}")
     target_link_libraries (hotrod-static ${platform_libs}  ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} hotrod_protobuf)
 
-add_custom_target(build_dist COMMAND "echo" "build_dist completed")
-add_dependencies(build_dist hotrod hotrod-static docs)
+    add_custom_target(build_dist COMMAND "echo" "build_dist completed")
+    add_dependencies(build_dist hotrod hotrod-static docs)
 endif(DEFINED HOTROD_PREBUILT_LIB_DIR)
 if (NOT DEFINED COMPILER_FLAGS)
     message(FATAL_ERROR "Compiler flags not set for this build type")
@@ -851,7 +850,7 @@ install (FILES "${CMAKE_CURRENT_SOURCE_DIR}/License.txt" "${CMAKE_CURRENT_SOURCE
 install (DIRECTORY ${PROTOBUF_INCLUDE_DIRS}/google/protobuf DESTINATION include/google)
 get_filename_component(real_protobuf_library "${PROTOBUF_LIBRARY}" REALPATH)
 get_filename_component(real_protoc_library "${PROTOBUF_PROTOC_LIBRARY}" REALPATH)
-install (FILES ${real_protobuf_library} ${real_protoc_library} ${PROTOBUF_LIBRARY} ${PROTOBUF_PROTOC_LIBRARY} DESTINATION lib${LIB_SUFFIX})
+install (FILES ${real_protobuf_library} ${real_protoc_library} ${PROTOBUF_LIBRARY} ${PROTOBUF_PROTOC_LIBRARY} DESTINATION lib)
 install (FILES ${PROTOBUF_PROTOC_EXECUTABLE}
          DESTINATION bin
          PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ WORLD_READ)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,9 +102,11 @@ set_target_properties(libgmock PROPERTIES
 include_directories("${source_dir}/googletest/include"
                     "${source_dir}/googlemock/include")
 
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/infinispan/hotrod)
+
 find_package(Protobuf REQUIRED)
 
-function(HR_PROTOBUF_GENERATE_CPP SRCS HDRS)
+function(hr_protobuf_generate_cpp SRCS HDRS DEST_PATH)
   if(NOT ARGN)
     message(SEND_ERROR "Error: PROTOBUF_GENERATE_CPP() called without any proto files")
     return()
@@ -140,14 +142,14 @@ function(HR_PROTOBUF_GENERATE_CPP SRCS HDRS)
     get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
     get_filename_component(FIL_WE ${FIL} NAME_WE)
 
-    list(APPEND ${SRCS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.cc")
-    list(APPEND ${HDRS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h")
+    list(APPEND ${SRCS} "${CMAKE_CURRENT_BINARY_DIR}/${DEST_PATH}/${FIL_WE}.pb.cc")
+    list(APPEND ${HDRS} "${CMAKE_CURRENT_BINARY_DIR}/${DEST_PATH}/${FIL_WE}.pb.h")
 
     add_custom_command(
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.cc"
-             "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h"
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${DEST_PATH}/${FIL_WE}.pb.cc"
+             "${CMAKE_CURRENT_BINARY_DIR}/${DEST_PATH}/${FIL_WE}.pb.h"
       COMMAND  ${PROTOBUF_PROTOC_EXECUTABLE}
-      ARGS --cpp_out dllexport_decl=HR_PROTO_EXPORT:${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${ABS_FIL}
+      ARGS --cpp_out dllexport_decl=HR_PROTO_EXPORT:${CMAKE_CURRENT_BINARY_DIR}/${DEST_PATH} ${_protobuf_include_path} ${ABS_FIL}
       DEPENDS ${ABS_FIL}
       COMMENT "Running C++ protocol buffer compiler on ${FIL}"
       VERBATIM )
@@ -468,7 +470,7 @@ endif(ENABLE_INTERNAL_TESTING)
       ${internal_test_sources}  
       ${CMAKE_BINARY_DIR}/Version.cpp
     )
-hr_protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS 
+hr_protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS infinispan/hotrod
   proto/infinispan/hotrod/protobuf/base_types.proto
   proto/org/infinispan/protostream/message-wrapping.proto
   proto/org/infinispan/query/remote/client/query.proto
@@ -535,7 +537,7 @@ endif (ENABLE_VALGRIND)
 
 file(COPY ${CMAKE_SOURCE_DIR}/test/query_proto DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 
-hr_protobuf_generate_cpp(TEST_PROTO_SRCS TEST_PROTO_HDRS 
+hr_protobuf_generate_cpp(TEST_PROTO_SRCS TEST_PROTO_HDRS .
   test/query_proto/addressbook.proto
   test/query_proto/bank.proto
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ ExternalProject_Add(
     INSTALL_COMMAND ""
 )
 
+set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
 
 # Get GTest source and binary directories from CMake project
 ExternalProject_Get_Property(gtest source_dir binary_dir)
@@ -187,10 +188,10 @@ if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set (COMPILER_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden -std=c++11")
   if (CMAKE_COMPILER_IS_GNUCXX)
   set (WARNING_FLAGS
-        "${WERROR} -pedantic -Wall -Wextra -Wno-shadow -Wpointer-arith -Wcast-qual -Wcast-align -Wno-long-long -Wvolatile-register-var -Winvalid-pch -Wno-system-headers -Woverloaded-virtual -Wno-variadic-macros -Wno-error=shadow")
+        "${WERROR} -pedantic -Wall -Wextra -Wno-shadow -Wpointer-arith -Wcast-qual -Wcast-align -Wno-long-long -Wvolatile-register-var -Winvalid-pch -Wno-system-headers -Woverloaded-virtual -Wno-variadic-macros -Wno-error=shadow -Wimplicit-fallthrough=0")
   set (WARNING_FLAGS_NO_PEDANTIC
         "${WERROR} -Wall -Wextra -Wno-shadow -Wpointer-arith -Wcast-qual -Wcast-align -Wno-long-long -Wvolatile-register-var -Winvalid-pch -Wno-system-headers -Woverloaded-virtual -Wno-variadic-macros -Wno-error=shadow")
-set (NO_UNUSED_FLAGS "-Wno-error=unused-parameter -Wno-unused-parameter")
+set (NO_UNUSED_FLAGS "-Wno-error=unused-parameter -Wno-unused-parameter -Wimplicit-fallthrough=0")
   endif (CMAKE_COMPILER_IS_GNUCXX)
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set (WARNING_FLAGS_NO_PEDANTIC
@@ -497,6 +498,7 @@ endif (MSVC)
     add_library (hotrod SHARED ${library_sources})
     
     set_target_properties(hotrod PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}")
+    set_target_properties(hotrod PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS} ${STATIC_FLAGS}")
     target_link_libraries (hotrod ${platform_libs}  ${OPENSSL_LIBRARIES} hotrod_protobuf ${PROTOBUF_LIBRARY})
     
     if (WIN32 AND NOT CMAKE_SIZEOF_VOID_P MATCHES "8")
@@ -541,6 +543,14 @@ hr_protobuf_generate_cpp(TEST_PROTO_SRCS TEST_PROTO_HDRS .
   test/query_proto/addressbook.proto
   test/query_proto/bank.proto
 )
+
+add_custom_target(build_dist COMMAND "echo" "build_dist completed")
+add_dependencies(build_dist hotrod hotrod-static docs)
+
+add_custom_target(build_test COMMAND "echo" "build_test completed")
+add_dependencies(build_test JniTest krbserver unittest unittest-static simple simple-static queryTest queryTest-static events
+                            nearCacheTest continuousQueryTest continuousQueryTest-static
+                            simpleSasl simple-tls simple-tls-sni simpleSaslTls PutGetTest QueryTest ClearTest xunit_nearCacheTest)
 
 # TESTS
 
@@ -755,7 +765,7 @@ endif (ENABLE_INTERNAL_TESTING)
 
 find_program(MVN_PROGRAM "mvn")
 if (MVN_PROGRAM STREQUAL "MVN_PROGRAM-NOTFOUND")
-    message(FATAL_ERROR "Apache Maven (mvn) not found in path")
+    message(WARNING "Apache Maven (mvn) not found in path")
 endif (MVN_PROGRAM STREQUAL "MVN_PROGRAM-NOTFOUND")
 
 set(KRBSERVER_DIR "${CMAKE_CURRENT_BINARY_DIR}/krbserver")
@@ -873,7 +883,7 @@ set (CPACK_SYSTEM_NAME "${PLATFORM}-${PACKAGE_ARCH}")
 if(WIN32)
 set (DOCDIR .)
 else(WIN32)
-    set (DOCDIR ${SHARE_INSTALL_PREFIX}/doc/${CMAKE_PROJECT_NAME})
+    set (DOCDIR ${SHARE_INSTALL_PREFIX}doc/${CMAKE_PROJECT_NAME})
 endif(WIN32)
 message (STATUS "OpenSSL support ${OPENSSL_FOUND}")
 
@@ -887,7 +897,9 @@ install (DIRECTORY ${PROTOBUF_INCLUDE_DIRS}/google/protobuf DESTINATION include/
 get_filename_component(real_protobuf_library "${PROTOBUF_LIBRARY}" REALPATH)
 get_filename_component(real_protoc_library "${PROTOBUF_PROTOC_LIBRARY}" REALPATH)
 install (FILES ${real_protobuf_library} ${real_protoc_library} ${PROTOBUF_LIBRARY} ${PROTOBUF_PROTOC_LIBRARY} DESTINATION lib${LIB_SUFFIX})
-install (FILES ${PROTOBUF_PROTOC_EXECUTABLE} DESTINATION bin)
+install (FILES ${PROTOBUF_PROTOC_EXECUTABLE}
+         DESTINATION bin
+         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ WORLD_READ)
 if (NOT WIN32)
     get_filename_component(protobuf_dir "${PROTOBUF_LIBRARY}" PATH)
     file(GLOB libproto_glob "${protobuf_dir}/libproto*")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,72 +247,15 @@ option(ENABLE_VALGRIND "Enable running the tests using Valgrind" ${DEFAULT_VALGR
 
 if(DEFINED HOTROD_PREBUILT_LIB_DIR)
     set(PROTOBUF_GENERATE_CPP_APPEND_PATH true)
+    set (INCLUDE_FILES_DIR ${HOTROD_PREBUILT_LIB_DIR}/../include)
+    include_directories(${INCLUDE_FILES_DIR})
 
-    if (DEFINED HOTROD_USE_CMAKE_PREFIX)
-        set(CMAKE_PREFIX_PATH "${HOTROD_PREBUILT_LIB_DIR}")
-        message("---- Searching in prefix: ${CMAKE_PREFIX_PATH}")
-
-        find_program(PROTOC_EXECUTABLE NAMES protoc)
-        if("${PROTOC_EXECUTABLE}" STREQUAL "PROTOC_EXECUTABLE-NOTFOUND")
-            message(FATAL_ERROR "Cannot find Protobuf compiler executable in directory '${HOTROD_PREBUILT_LIB_DIR}/bin'.")
-        else("${PROTOC_EXECUTABLE}" STREQUAL "PROTOC_EXECUTABLE-NOTFOUND")
-            message("-- Found Protobuf compiler executable: ${PROTOC_EXECUTABLE}")
-            set (PROTOBUF_PROTOC_EXECUTABLE ${PROTOC_EXECUTABLE})
-        endif("${PROTOC_EXECUTABLE}" STREQUAL "PROTOC_EXECUTABLE-NOTFOUND")
-
-        # On Windows Protobuf libraries have a "lib" prefix
-        if(WIN32)
-            SET(CMAKE_FIND_LIBRARY_PREFIXES "lib")
-        endif(WIN32)
-    
-        find_library(PROTOBUF_LIBRARY NAMES protobuf)
-        if("${PROTOBUF_LIBRARY}" STREQUAL "PROTOBUF_LIBRARY-NOTFOUND")
-            message(FATAL_ERROR "Cannot find Protobuf dynamic library in directory '${HOTROD_PREBUILT_LIB_DIR}/lib64 or ${HOTROD_PREBUILT_LIB_DIR}/lib'.")
-        else("${PROTOBUF_LIBRARY}" STREQUAL "PROTOBUF_LIBRARY-NOTFOUND")
-            message("-- Found Protobuf dynamic library: ${PROTOBUF_LIBRARY}")
-            add_library(protobuf SHARED IMPORTED GLOBAL)
-            set_target_properties(protobuf PROPERTIES IMPORTED_LOCATION ${PROTOBUF_LIBRARY})
-        endif("${PROTOBUF_LIBRARY}" STREQUAL "PROTOBUF_LIBRARY-NOTFOUND")
-    
-        find_library(PROTOBUF_PROTOC_LIBRARY NAMES protoc)
-        if("${PROTOBUF_PROTOC_LIBRARY}" STREQUAL "PROTOBUF_PROTOC_LIBRARY-NOTFOUND")
-            message(FATAL_ERROR "Cannot find Protobuf compiler library in directory '${HOTROD_PREBUILT_LIB_DIR}/lib64 or ${HOTROD_PREBUILT_LIB_DIR}/lib'.")
-        else("${PROTOBUF_PROTOC_LIBRARY}" STREQUAL "PROTOBUF_PROTOC_LIBRARY-NOTFOUND")
-            message("-- Found Protobuf compiler library: ${PROTOBUF_PROTOC_LIBRARY}")
-            add_library(protoc SHARED IMPORTED GLOBAL)
-            set_target_properties(protoc PROPERTIES IMPORTED_LOCATION ${PROTOBUF_PROTOC_LIBRARY})
-        endif("${PROTOBUF_PROTOC_LIBRARY}" STREQUAL "PROTOBUF_PROTOC_LIBRARY-NOTFOUND")
-        
-        set(PROTOBUF_LIBRARIES ${PROTOBUF_LIBRARY} ${PROTOBUF_PROTOC_LIBRARY})
-        
-        # On Windows HotRod libraries don't have a "lib" prefix
-        if(WIN32)
-            SET(CMAKE_FIND_LIBRARY_PREFIXES "")
-        endif(WIN32)
-        
-        find_library(HOTROD_PROTOBUF_LIBRARY NAMES hotrod_protobuf)
-        if("${HOTROD_PROTOBUF_LIBRARY}" STREQUAL "HOTROD_PROTOBUF_LIBRARY-NOTFOUND")
-            message(FATAL_ERROR "Cannot find HotRod protobuf static library in directory '${HOTROD_PREBUILT_LIB_DIR}/lib64 or ${HOTROD_PREBUILT_LIB_DIR}/lib'.")
-        else("${HOTROD_PROTOBUF_LIBRARY}" STREQUAL "HOTROD_PROTOBUF_LIBRARY-NOTFOUND")
-            message("-- Found HotRod protobuf static library: ${HOTROD_PROTOBUF_LIBRARY}")
-            add_library(hotrod_protobuf STATIC IMPORTED GLOBAL)
-            set_target_properties(hotrod_protobuf PROPERTIES IMPORTED_LOCATION ${HOTROD_PROTOBUF_LIBRARY})
-        endif("${HOTROD_PROTOBUF_LIBRARY}" STREQUAL "HOTROD_PROTOBUF_LIBRARY-NOTFOUND")
-  
-        set (PROTOBUF_INCLUDE_DIR ${HOTROD_PREBUILT_LIB_DIR}/include)
-        message("-- Found Protobuf include directory: ${PROTOBUF_INCLUDE_DIR}")
-        include_directories(${PROTOBUF_INCLUDE_DIR})
-        include_directories(${HOTROD_PREBUILT_LIB_DIR}/include)
-      
-    else (DEFINED HOTROD_USE_CMAKE_PREFIX)
-        set (INCLUDE_FILES_DIR ${HOTROD_PREBUILT_LIB_DIR}/../include)
-        include_directories(${INCLUDE_FILES_DIR})
-    
-        find_library(HOTROD_LIBRARY NAMES hotrod PATHS ${HOTROD_PREBUILT_LIB_DIR} NO_DEFAULT_PATH)
+    # Find hotrod libraries looking only into the distro pack
+    find_library(HOTROD_LIBRARY NAMES hotrod PATHS ${HOTROD_PREBUILT_LIB_DIR} NO_DEFAULT_PATH)
     if("${HOTROD_LIBRARY}" STREQUAL "HOTROD_LIBRARY-NOTFOUND")
         message(FATAL_ERROR "Cannot find HotRod dynamic library in directory '${HOTROD_PREBUILT_LIB_DIR}'.")
     else("${HOTROD_LIBRARY}" STREQUAL "HOTROD_LIBRARY-NOTFOUND")
-            message("-- Found HotRod dynamic library: ${HOTROD_LIBRARY}")
+        message("-- Found HotRod dynamic library: ${HOTROD_LIBRARY}")
         add_library(hotrod SHARED IMPORTED GLOBAL)
         set_target_properties(hotrod PROPERTIES IMPORTED_LOCATION ${HOTROD_LIBRARY})
         set_target_properties(hotrod PROPERTIES IMPORTED_IMPLIB ${HOTROD_LIBRARY})
@@ -321,50 +264,63 @@ if(DEFINED HOTROD_PREBUILT_LIB_DIR)
             add_custom_target(copyhrlibs ALL COMMAND ${CMAKE_COMMAND} -E copy_directory ${HOTROD_PREBUILT_LIB_DIR} ${CMAKE_CFG_INTDIR})
         endif(WIN32)
     endif("${HOTROD_LIBRARY}" STREQUAL "HOTROD_LIBRARY-NOTFOUND")
-    find_library(HOTROD_STATIC_LIBRARY NAMES hotrod-static PATHS ${HOTROD_PREBUILT_LIB_DIR})
+
+    # Find hotrod static libraries looking only into the distro pack
+    find_library(HOTROD_STATIC_LIBRARY NAMES hotrod-static PATHS ${HOTROD_PREBUILT_LIB_DIR} NO_DEFAULT_PATH)
     if("${HOTROD_STATIC_LIBRARY}" STREQUAL "HOTROD_STATIC_LIBRARY-NOTFOUND")
         message(FATAL_ERROR "Cannot find HotRod static library in directory '${HOTROD_PREBUILT_LIB_DIR}'.")
     else("${HOTROD_STATIC_LIBRARY}" STREQUAL "HOTROD_STATIC_LIBRARY-NOTFOUND")
-            message("-- Found HotRod static library: ${HOTROD_STATIC_LIBRARY}")
+        message("-- Found HotRod static library: ${HOTROD_STATIC_LIBRARY}")
         add_library(hotrod-static STATIC IMPORTED GLOBAL)
         set_target_properties(hotrod-static PROPERTIES IMPORTED_LOCATION ${HOTROD_STATIC_LIBRARY})
     endif("${HOTROD_STATIC_LIBRARY}" STREQUAL "HOTROD_STATIC_LIBRARY-NOTFOUND")
 
-        find_library(HOTROD_PROTOBUF_LIBRARY NAMES hotrod_protobuf PATHS ${HOTROD_PREBUILT_LIB_DIR})
-        if("${HOTROD_PROTOBUF_LIBRARY}" STREQUAL "HOTROD_PROTOBUF_LIBRARY-NOTFOUND")
-            message(FATAL_ERROR "Cannot find HotRod Protobuf static library in directory '${HOTROD_PREBUILT_LIB_DIR}'.")
-        else("${HOTROD_PROTOBUF_LIBRARY}" STREQUAL "HOTROD_PROTOBUF_LIBRARY-NOTFOUND")
-            message("-- Found HotRod Protobuf static library: ${HOTROD_PROTOBUF_LIBRARY}")
-            add_library(hotrod_protobuf STATIC IMPORTED GLOBAL)
-            set_target_properties(hotrod_protobuf PROPERTIES IMPORTED_LOCATION ${HOTROD_PROTOBUF_LIBRARY})
-        endif("${HOTROD_PROTOBUF_LIBRARY}" STREQUAL "HOTROD_PROTOBUF_LIBRARY-NOTFOUND")
-  
+    # Find hotrod_protobuf static libraries looking only into the distro pack
+    find_library(HOTROD_PROTOBUF_LIBRARY NAMES hotrod_protobuf PATHS ${HOTROD_PREBUILT_LIB_DIR} NO_DEFAULT_PATH)
+    if("${HOTROD_PROTOBUF_LIBRARY}" STREQUAL "HOTROD_PROTOBUF_LIBRARY-NOTFOUND")
+        message(FATAL_ERROR "Cannot find HotRod Protobuf static library in directory '${HOTROD_PREBUILT_LIB_DIR}'.")
+    else("${HOTROD_PROTOBUF_LIBRARY}" STREQUAL "HOTROD_PROTOBUF_LIBRARY-NOTFOUND")
+        message("-- Found HotRod Protobuf static library: ${HOTROD_PROTOBUF_LIBRARY}")
+        add_library(hotrod_protobuf STATIC IMPORTED GLOBAL)
+        set_target_properties(hotrod_protobuf PROPERTIES IMPORTED_LOCATION ${HOTROD_PROTOBUF_LIBRARY})
+    endif("${HOTROD_PROTOBUF_LIBRARY}" STREQUAL "HOTROD_PROTOBUF_LIBRARY-NOTFOUND")
+
+    # Find protobuf libraries looking only into the distro pack
+    if(DEFINED HR_USE_SYSTEM_PROTOBUF)
+        # look into the system defaults
+        find_library(HR_PROTOBUF_LIBRARY NAMES libprotobuf.a libprotobuf.lib protobuf)
+    else(DEFINED HR_USE_SYSTEM_PROTOBUF)
+        # look only into the distro pack
         find_library(HR_PROTOBUF_LIBRARY NAMES libprotobuf.a libprotobuf.lib protobuf  PATHS ${HOTROD_PREBUILT_LIB_DIR}
-                NO_SYSTEM_ENVIRONMENT_PATH NO_DEFAULT_PATH
-                NO_CMAKE_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_DEFAULT_PATH)
-        if("${HR_PROTOBUF_LIBRARY}" STREQUAL "HR_PROTOBUF_LIBRARY-NOTFOUND")
-            message(FATAL_ERROR "Cannot find protobuf static library in directory '${HOTROD_PREBUILT_LIB_DIR}'.")
-        else("${HR_PROTOBUF_LIBRARY}" STREQUAL "HR_PROTOBUF_LIBRARY-NOTFOUND")
-            message("-- Found Protobuf static library: ${HR_PROTOBUF_LIBRARY}")
-            add_library(protobuf STATIC IMPORTED GLOBAL)
-            set_target_properties(protobuf PROPERTIES IMPORTED_LOCATION ${HR_PROTOBUF_LIBRARY})
-            set_target_properties(protobuf PROPERTIES IMPORTED_IMPLIB ${HR_PROTOBUF_LIBRARY})
-            set(PROTOBUF_LIBRARY ${HR_PROTOBUF_LIBRARY})
-        endif("${HR_PROTOBUF_LIBRARY}" STREQUAL "HR_PROTOBUF_LIBRARY-NOTFOUND")
+            NO_SYSTEM_ENVIRONMENT_PATH NO_DEFAULT_PATH
+            NO_CMAKE_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_DEFAULT_PATH)
+    endif(DEFINED HR_USE_SYSTEM_PROTOBUF)
+    if("${HR_PROTOBUF_LIBRARY}" STREQUAL "HR_PROTOBUF_LIBRARY-NOTFOUND")
+        message(FATAL_ERROR "Cannot find protobuf static library in directory '${HOTROD_PREBUILT_LIB_DIR}'.")
+    else("${HR_PROTOBUF_LIBRARY}" STREQUAL "HR_PROTOBUF_LIBRARY-NOTFOUND")
+        message("-- Found Protobuf static library: ${HR_PROTOBUF_LIBRARY}")
+        add_library(protobuf STATIC IMPORTED GLOBAL)
+        set_target_properties(protobuf PROPERTIES IMPORTED_LOCATION ${HR_PROTOBUF_LIBRARY})
+        set_target_properties(protobuf PROPERTIES IMPORTED_IMPLIB ${HR_PROTOBUF_LIBRARY})
+        set(PROTOBUF_LIBRARY ${HR_PROTOBUF_LIBRARY})
+    endif("${HR_PROTOBUF_LIBRARY}" STREQUAL "HR_PROTOBUF_LIBRARY-NOTFOUND")
 
-        if(NOT DEFINED WIN32)
-            find_package(OpenSSL)
-            include_directories(${OPENSSL_INCLUDE_DIR})
-         endif(NOT DEFINED WIN32)
+    # Find OpenSSL
+    if(NOT DEFINED WIN32)
+        find_package(OpenSSL)
+        include_directories(${OPENSSL_INCLUDE_DIR})
+    endif(NOT DEFINED WIN32)
 
-        if(UNIX) 
-            set (PROTOBUF_PROTOC_EXECUTABLE ${HOTROD_PREBUILT_LIB_DIR}/../bin/protoc)
-        else(UNIX) 
-            set (PROTOBUF_PROTOC_EXECUTABLE ${HOTROD_PREBUILT_LIB_DIR}/../bin/protoc.exe)
-        endif(UNIX) 
-        set (PROTOBUF_INCLUDE_DIR ${HOTROD_PREBUILT_LIB_DIR}/../include)
-    endif (DEFINED HOTROD_USE_CMAKE_PREFIX)
+
+    #FIND protoc executable
+    if(UNIX)
+        set (PROTOBUF_PROTOC_EXECUTABLE ${HOTROD_PREBUILT_LIB_DIR}/../bin/protoc)
+    else(UNIX)
+        set (PROTOBUF_PROTOC_EXECUTABLE ${HOTROD_PREBUILT_LIB_DIR}/../bin/protoc.exe)
+    endif(UNIX)
+    set (PROTOBUF_INCLUDE_DIR ${HOTROD_PREBUILT_LIB_DIR}/../include)
 else(DEFINED HOTROD_PREBUILT_LIB_DIR)
+
 find_package(Protobuf REQUIRED)
 
 # OpenSSL support
@@ -518,6 +474,8 @@ endif (MSVC)
     set_target_properties(hotrod-static PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS} ${STATIC_FLAGS}")
     target_link_libraries (hotrod-static ${platform_libs}  ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} hotrod_protobuf)
 
+add_custom_target(build_dist COMMAND "echo" "build_dist completed")
+add_dependencies(build_dist hotrod hotrod-static docs)
 endif(DEFINED HOTROD_PREBUILT_LIB_DIR)
 if (NOT DEFINED COMPILER_FLAGS)
     message(FATAL_ERROR "Compiler flags not set for this build type")
@@ -543,9 +501,6 @@ hr_protobuf_generate_cpp(TEST_PROTO_SRCS TEST_PROTO_HDRS .
   test/query_proto/addressbook.proto
   test/query_proto/bank.proto
 )
-
-add_custom_target(build_dist COMMAND "echo" "build_dist completed")
-add_dependencies(build_dist hotrod hotrod-static docs)
 
 add_custom_target(build_test COMMAND "echo" "build_test completed")
 add_dependencies(build_test JniTest krbserver unittest unittest-static simple simple-static queryTest queryTest-static events

--- a/include/infinispan/hotrod/BasicTypesProtoStreamMarshaller.h
+++ b/include/infinispan/hotrod/BasicTypesProtoStreamMarshaller.h
@@ -10,7 +10,7 @@
 #pragma warning(push)
 #pragma warning(disable:4267 4244)
 #endif
-#include "base_types.pb.h"
+#include "infinispan/hotrod/base_types.pb.h"
 #if _MSC_VER
 #pragma warning(pop)
 #endif

--- a/include/infinispan/hotrod/ProtoStreamMarshaller.h
+++ b/include/infinispan/hotrod/ProtoStreamMarshaller.h
@@ -10,7 +10,7 @@
 #pragma warning(push)
 #pragma warning(disable:4267 4244)
 #endif
-#include "message-wrapping.pb.h"
+#include "infinispan/hotrod/message-wrapping.pb.h"
 #if _MSC_VER
 #pragma warning(pop)
 #endif

--- a/include/infinispan/hotrod/Query.h
+++ b/include/infinispan/hotrod/Query.h
@@ -7,7 +7,7 @@
 
 #ifndef INCLUDE_INFINISPAN_HOTROD_QUERY_H_
 #define INCLUDE_INFINISPAN_HOTROD_QUERY_H_
-#include "query.pb.h"
+#include "infinispan/hotrod/query.pb.h"
 #include <tuple>
 
 using namespace org::infinispan::protostream;

--- a/jni/swig.cmake
+++ b/jni/swig.cmake
@@ -42,7 +42,14 @@ set(CMAKE_SWIG_OUTDIR "${JNI_DIR}/src/main/java/org/infinispan/client/hotrod/jni
 set(CMAKE_SWIG_FLAGS -package "org.infinispan.client.hotrod.jni")
 set_source_files_properties("jni/src/main/swig/java.i" PROPERTIES CPLUSPLUS ON)
 
-swig_add_module(hotrod-swig java "${CMAKE_CURRENT_SOURCE_DIR}/jni/src/main/swig/java.i")
+if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
+    swig_add_module(hotrod-swig java "${CMAKE_CURRENT_SOURCE_DIR}/jni/src/main/swig/java.i")
+else()
+    swig_add_library(hotrod-swig
+        LANGUAGE java
+        SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/jni/src/main/swig/java.i")
+endif()
+
 include_directories(${JNI_INCLUDE_DIRS})
 if(DEFINED HOTROD_PREBUILT_LIB_DIR)
     set (INCLUDE_FILES_DIR ${HOTROD_PREBUILT_LIB_DIR}/../include)

--- a/jni/swig.cmake
+++ b/jni/swig.cmake
@@ -86,6 +86,9 @@ set(JAVA_LIBRARY_PATH ".")
 foreach(loop_var ${CMAKE_CONFIGURATION_TYPES})
 	set(JAVA_LIBRARY_PATH "${JAVA_LIBRARY_PATH}${CLASSPATH_SEPARATOR}${loop_var}")
 endforeach(loop_var)
+if(DEFINED HOTROD_PREBUILT_LIB_DIR)
+	set(JAVA_LIBRARY_PATH "${JAVA_LIBRARY_PATH}${CLASSPATH_SEPARATOR}${HOTROD_PREBUILT_LIB_DIR}")
+endif(DEFINED HOTROD_PREBUILT_LIB_DIR)
 
 add_test(swig ${JAVA_RUNTIME} 
     -ea 
@@ -96,7 +99,5 @@ add_test(swig ${JAVA_RUNTIME}
     org.infinispan.client.jni.hotrod.JniTest
 )
 
-install (FILES "${CMAKE_CURRENT_BINARY_DIR}/jni/target/hotrod-jni.jar" DESTINATION jni)
 set_property(TARGET hotrod-swig PROPERTY CXX_STANDARD 11)
 set_property(TARGET hotrod-swig PROPERTY CXX_STANDARD_REQUIRED ON)
-install (TARGETS hotrod-swig LIBRARY DESTINATION jni)

--- a/proto/infinispan/hotrod/protobuf/base_types.proto
+++ b/proto/infinispan/hotrod/protobuf/base_types.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package infinispan.hotrod.protobuf;
 message base_types {
     optional int64 i64  = 3;

--- a/proto/org/infinispan/protostream/message-wrapping.proto
+++ b/proto/org/infinispan/protostream/message-wrapping.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package org.infinispan.protostream;
 
 /*

--- a/proto/org/infinispan/query/remote/client/query.proto
+++ b/proto/org/infinispan/query/remote/client/query.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "message-wrapping.proto";
 
 package org.infinispan.query.remote.client;

--- a/src/hotrod/impl/protocol/Codec20.cpp
+++ b/src/hotrod/impl/protocol/Codec20.cpp
@@ -275,7 +275,7 @@ void Codec20::writeClientListenerParams(transport::Transport& t, const ClientLis
     this->writeNamedFactory(t, clientListener.converterFactoryName, converterFactoryParams);
 }
 
-void Codec20::writeClientListenerInterests(transport::Transport& t, unsigned char) const
+void Codec20::writeClientListenerInterests(transport::Transport& , unsigned char) const
 {
 	// Called by the Add Listener operation, but no op until 2.6
 }

--- a/xunit-test/ClearTest/CMakeLists.txt
+++ b/xunit-test/ClearTest/CMakeLists.txt
@@ -7,11 +7,7 @@ set_property(TARGET ClearTest PROPERTY CXX_STANDARD 11)
 set_property(TARGET ClearTest PROPERTY CXX_STANDARD_REQUIRED ON)
 set_target_properties (ClearTest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${STATIC_FLAGS} ${NO_UNUSED_FLAGS}")
 set_target_properties(ClearTest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
-target_link_libraries(ClearTest
-    hotrod-static
-    libgtest
-    ${platform_libs}
-)
+target_link_libraries(ClearTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} libgtest ${platform_libs})
 
 add_test (start_server ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/server_ctl.py start ${JAVA_RUNTIME} ${HOTROD_JBOSS_HOME} standalone.xml)
 add_test (probe_port ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)

--- a/xunit-test/NearCacheTest/CMakeLists.txt
+++ b/xunit-test/NearCacheTest/CMakeLists.txt
@@ -8,11 +8,7 @@ set_property(TARGET xunit_nearCacheTest PROPERTY CXX_STANDARD_REQUIRED ON)
 set_target_properties (xunit_nearCacheTest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${STATIC_FLAGS} ${NO_UNUSED_FLAGS}")
 set_target_properties(xunit_nearCacheTest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
 
-target_link_libraries(xunit_nearCacheTest
-    hotrod-static
-    libgtest
-    ${platform_libs}
-)
+target_link_libraries(xunit_nearCacheTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} libgtest ${platform_libs})
 
 add_test (start_server ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/server_ctl.py start ${JAVA_RUNTIME} ${HOTROD_JBOSS_HOME} standalone.xml)
 add_test (probe_port ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)

--- a/xunit-test/PutGetTest/CMakeLists.txt
+++ b/xunit-test/PutGetTest/CMakeLists.txt
@@ -8,11 +8,7 @@ set_property(TARGET PutGetTest PROPERTY CXX_STANDARD_REQUIRED ON)
 set_target_properties (PutGetTest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${STATIC_FLAGS} ${NO_UNUSED_FLAGS}")
 set_target_properties(PutGetTest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
 
-target_link_libraries(PutGetTest
-    hotrod-static
-    libgtest
-    ${platform_libs}
-)
+target_link_libraries(PutGetTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} libgtest ${platform_libs})
 
 add_test (start_server ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/server_ctl.py start ${JAVA_RUNTIME} ${HOTROD_JBOSS_HOME} standalone.xml)
 add_test (probe_port ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)

--- a/xunit-test/QueryTest/CMakeLists.txt
+++ b/xunit-test/QueryTest/CMakeLists.txt
@@ -3,7 +3,7 @@ file(GLOB SRCS *.cpp)
 
 file(COPY ${CMAKE_ROOT_SOURCE_DIR}/test/query_proto/bank-xunit.proto DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 
-hr_protobuf_generate_cpp(TEST_PROTO_SRCS TEST_PROTO_HDRS 
+hr_protobuf_generate_cpp(TEST_PROTO_SRCS TEST_PROTO_HDRS .
   ${CMAKE_ROOT_SOURCE_DIR}/test/query_proto/bank-xunit.proto
 )
 

--- a/xunit-test/QueryTest/CMakeLists.txt
+++ b/xunit-test/QueryTest/CMakeLists.txt
@@ -15,11 +15,7 @@ set_property(TARGET QueryTest PROPERTY CXX_STANDARD_REQUIRED ON)
 set_target_properties (QueryTest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${STATIC_FLAGS} ${NO_UNUSED_FLAGS}")
 set_target_properties(QueryTest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
 
-target_link_libraries(QueryTest
-    hotrod-static
-    libgtest
-    ${platform_libs}
-)
+target_link_libraries(QueryTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${platform_libs} libgtest)
 
 add_test (start_server ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/server_ctl.py start ${JAVA_RUNTIME} ${HOTROD_JBOSS_HOME} clustered-indexing.xml)
 add_test (probe_port ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)

--- a/xunit-test/QueryTest/QueryTest.cpp
+++ b/xunit-test/QueryTest/QueryTest.cpp
@@ -3,7 +3,7 @@
 #include <infinispan/hotrod/BasicTypesProtoStreamMarshaller.h>
 #include <infinispan/hotrod/ProtoStreamMarshaller.h>
 #include "QueryTest.h"
-#include "query.pb.h"
+#include "infinispan/hotrod/query.pb.h"
 #include "infinispan/hotrod/QueryUtils.h"
 
 #include <cstdio>


### PR DESCRIPTION
https://issues.jboss.org/browse/HRCPP-436
This adds two new target for the build:

- build_dist
- build_test

The intended use is as follows.

**Build the distribution pack**
no need for maven or gtest

cd build
cmake ..
cmake --build . --target build_dist
cpack

**Build test against prebuilt**
no need for the full build

cd build
cmake .. -DHOTROD_JBOSS_HOME=&lt;path to jboss&gt; -DHOTROD_PREBUILT_LIB_DIR=&lt;path to the client libs&gt;
cmake --build . --target build_test
ctest -V

If you want to use your system protobuf libraries you can add -DHR_USE_SYSTEM_PROTOBUF=ON to the cmake setup