### PR TITLE
HRCPP-467 removed com.sun.security.sasl.digest.utf8 property. See ELY…

### DIFF
--- a/test/data/standalone-sasl-nokrb.xml
+++ b/test/data/standalone-sasl-nokrb.xml
@@ -206,9 +206,6 @@
                         <policy>
                             <no-anonymous value="true"/>
                         </policy>
-                        <property name="com.sun.security.sasl.digest.utf8">
-                            true
-                        </property>
                     </sasl>
                 </authentication>
             </hotrod-connector>

--- a/test/data/standalone-sasl-ssl.xml
+++ b/test/data/standalone-sasl-ssl.xml
@@ -166,7 +166,6 @@
                         <policy>
                             <no-anonymous value="true"/>
                         </policy>
-                        <property name="com.sun.security.sasl.digest.utf8">true</property>
                     </sasl>
                 </authentication>
                 <encryption security-realm="ApplicationRealm" require-ssl-client-auth="true">

--- a/test/data/standalone-sasl.xml
+++ b/test/data/standalone-sasl.xml
@@ -204,7 +204,6 @@
                     <policy>
                       <no-anonymous value="true"/>
                     </policy>
-                    <property name="com.sun.security.sasl.digest.utf8">true</property>
                   </sasl>
                 </authentication>
             </hotrod-connector>


### PR DESCRIPTION
…-1404

Fixes: https://issues.jboss.org/browse/HRCPP-467

No need to explicitly set the utf8 property since true is the default value.