### PR TITLE
fix googletest build on CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,58 +50,39 @@ include_directories ("${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOUR
 # Enable ExternalProject CMake module
 include(ExternalProject)
 
-# Download and install GoogleTest
-ExternalProject_Add(
-    gtest
-    URL https://github.com/google/googletest/archive/master.zip
-    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
-    CMAKE_ARGS -DCMAKE_BUILD_TYPE:STRING=Debug -Dgtest_force_shared_crt=ON
-    BUILD_COMMAND cmake --build . --config RelWithDebInfo
-    # Disable install step
-    INSTALL_COMMAND ""
-)
+# Download and unpack googletest at configure time
+configure_file(gtest-CMakeLists.txt.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+# Prevent overriding the parent project's compiler/linker
+# settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+                 ${CMAKE_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL)
+
+# The gtest/gtest_main targets carry header search path
+# dependencies automatically when using CMake 2.8.11 or
+# later. Otherwise we have to add them here ourselves.
+if (CMAKE_VERSION VERSION_LESS 2.8.11)
+  include_directories("${gtest_SOURCE_DIR}/include")
+endif()
 
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
-
-# Get GTest source and binary directories from CMake project
-ExternalProject_Get_Property(gtest source_dir binary_dir)
-
-# Create a libgtest target to be used as a dependency by test programs
-add_library(libgtest IMPORTED STATIC GLOBAL)
-add_dependencies(libgtest gtest)
-
-if(WIN32 AND NOT CYGWIN)
-    set(GTEST_LIBRARY "${binary_dir}/googlemock/gtest/RelWithDebInfo/gtest.lib")
-else(WIN32 AND NOT CYGWIN)
-    set(GTEST_LIBRARY "${binary_dir}/googlemock/gtest/libgtestd.a")
-endif(WIN32 AND NOT CYGWIN)
-
-# Set libgtest properties
-set_target_properties(libgtest PROPERTIES
-    "IMPORTED_LOCATION" "${GTEST_LIBRARY}"
-    "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
-)
-
-# Create a libgmock target to be used as a dependency by test programs
-add_library(libgmock IMPORTED STATIC GLOBAL)
-add_dependencies(libgmock gtest)
-
-# Set libgmock properties
-
-if(WIN32 AND NOT CYGWIN)
-    set(GMOCK_LIBRARY "${binary_dir}/googlemock/RelWithDebInfo/gmock.lib")
-else(WIN32 AND NOT CYGWIN)
-    set(GMOCK_LIBRARY "${binary_dir}/googlemock/libgmock.a")
-endif(WIN32 AND NOT CYGWIN)
-
-set_target_properties(libgmock PROPERTIES
-    "IMPORTED_LOCATION" "${GMOCK_LIBRARY}"
-    "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
-)
-
-# I couldn't make it work with INTERFACE_INCLUDE_DIRECTORIES
-include_directories("${source_dir}/googletest/include"
-                    "${source_dir}/googlemock/include")
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/infinispan/hotrod)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline{
                 sh 'printenv'
             }
             script {
-                sh "PATH=\"${env.JAVA_HOME}/bin:${env.M2_HOME}/bin:${PATH}\" ./build.sh"
+                sh "PATH=\"${env.JAVA_HOME}/bin:${env.M2_HOME}/bin:${PATH}\" CMAKE_EXTRAS=\"-DINSTALL_GTEST=FALSE\" ./build.sh"
                 archiveArtifacts artifacts: 'build/_CPack_Packages/RHEL-x86_64/RPM/*.rpm, build/*Source.zip'
             }
         }

--- a/gtest-CMakeLists.txt.in
+++ b/gtest-CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/xunit-test/ClearTest/CMakeLists.txt
+++ b/xunit-test/ClearTest/CMakeLists.txt
@@ -7,7 +7,7 @@ set_property(TARGET ClearTest PROPERTY CXX_STANDARD 11)
 set_property(TARGET ClearTest PROPERTY CXX_STANDARD_REQUIRED ON)
 set_target_properties (ClearTest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${STATIC_FLAGS} ${NO_UNUSED_FLAGS}")
 set_target_properties(ClearTest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
-target_link_libraries(ClearTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} libgtest ${platform_libs})
+target_link_libraries(ClearTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} gtest_main ${platform_libs})
 
 add_test (start_server ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/server_ctl.py start ${JAVA_RUNTIME} ${HOTROD_JBOSS_HOME} standalone.xml)
 add_test (probe_port ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)

--- a/xunit-test/CountersTest/CMakeLists.txt
+++ b/xunit-test/CountersTest/CMakeLists.txt
@@ -8,7 +8,7 @@ set_property(TARGET CountersTest PROPERTY CXX_STANDARD_REQUIRED ON)
 set_target_properties (CountersTest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${STATIC_FLAGS} ${NO_UNUSED_FLAGS}")
 set_target_properties(CountersTest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
 
-target_link_libraries(CountersTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} libgtest ${platform_libs})
+target_link_libraries(CountersTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} gtest_main ${platform_libs})
 
 add_test (start_server ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/server_ctl.py start ${JAVA_RUNTIME} ${HOTROD_JBOSS_HOME} clustered.xml)
 add_test (probe_port ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)

--- a/xunit-test/NearCacheTest/CMakeLists.txt
+++ b/xunit-test/NearCacheTest/CMakeLists.txt
@@ -8,7 +8,7 @@ set_property(TARGET xunit_nearCacheTest PROPERTY CXX_STANDARD_REQUIRED ON)
 set_target_properties (xunit_nearCacheTest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${STATIC_FLAGS} ${NO_UNUSED_FLAGS}")
 set_target_properties(xunit_nearCacheTest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
 
-target_link_libraries(xunit_nearCacheTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} libgtest ${platform_libs})
+target_link_libraries(xunit_nearCacheTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} gtest_main ${platform_libs})
 
 add_test (start_server ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/server_ctl.py start ${JAVA_RUNTIME} ${HOTROD_JBOSS_HOME} standalone.xml)
 add_test (probe_port ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)

--- a/xunit-test/PutGetTest/CMakeLists.txt
+++ b/xunit-test/PutGetTest/CMakeLists.txt
@@ -8,7 +8,7 @@ set_property(TARGET PutGetTest PROPERTY CXX_STANDARD_REQUIRED ON)
 set_target_properties (PutGetTest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${STATIC_FLAGS} ${NO_UNUSED_FLAGS}")
 set_target_properties(PutGetTest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
 
-target_link_libraries(PutGetTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} libgtest ${platform_libs})
+target_link_libraries(PutGetTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} gtest_main ${platform_libs})
 
 add_test (start_server ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/server_ctl.py start ${JAVA_RUNTIME} ${HOTROD_JBOSS_HOME} standalone.xml)
 add_test (probe_port ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)

--- a/xunit-test/QueryTest/CMakeLists.txt
+++ b/xunit-test/QueryTest/CMakeLists.txt
@@ -15,7 +15,7 @@ set_property(TARGET QueryTest PROPERTY CXX_STANDARD_REQUIRED ON)
 set_target_properties (QueryTest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${STATIC_FLAGS} ${NO_UNUSED_FLAGS}")
 set_target_properties(QueryTest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
 
-target_link_libraries(QueryTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${platform_libs} libgtest)
+target_link_libraries(QueryTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${platform_libs} gtest_main)
 
 add_test (start_server ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/server_ctl.py start ${JAVA_RUNTIME} ${HOTROD_JBOSS_HOME} clustered-indexing.xml)
 add_test (probe_port ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)

--- a/xunit-test/TransactionTest/CMakeLists.txt
+++ b/xunit-test/TransactionTest/CMakeLists.txt
@@ -8,7 +8,7 @@ set_property(TARGET TransactionTest PROPERTY CXX_STANDARD_REQUIRED ON)
 set_target_properties (TransactionTest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${STATIC_FLAGS} ${NO_UNUSED_FLAGS}")
 set_target_properties(TransactionTest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
 
-target_link_libraries(TransactionTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} libgtest ${platform_libs})
+target_link_libraries(TransactionTest hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} gtest_main ${platform_libs})
 
 add_test (start_server ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/server_ctl.py start ${JAVA_RUNTIME} ${HOTROD_JBOSS_HOME} standalone.xml)
 add_test (probe_port ${PYTHON_EXECUTABLE} ${CMAKE_ROOT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)


### PR DESCRIPTION
Last version of googletest fails on CI.

This PR updates the googletest integration and fix the build.
Relevant fix is on Jenkinsfile

https://issues.jboss.org/browse/HRCPP-483