### PR TITLE
HRCPP-485 Removed unnecessary mutex lock

### DIFF
--- a/src/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.cpp
+++ b/src/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.cpp
@@ -21,6 +21,7 @@ void RoundRobinBalancingStrategy::setServers(const std::vector<transport::InetSo
 }
 
 const transport::InetSocketAddress& RoundRobinBalancingStrategy::nextServer(const std::set<transport::InetSocketAddress>& /*failedServer*/) {
+    sys::ScopedLock<sys::Mutex> scopedLock(lock);
     const transport::InetSocketAddress& server = getServerByIndex(index++);
     if (index >= servers.size()) {
        index = 0;

--- a/src/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.h
+++ b/src/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.h
@@ -2,6 +2,7 @@
 #define ISPN_HOTROD_TRANSPORT_ROUNDROBINBALANCINGSTRATEGY_H
 
 #include "infinispan/hotrod/FailOverRequestBalancingStrategy.h"
+#include "hotrod/sys/Mutex.h"
 #include <set>
 
 namespace infinispan {
@@ -18,6 +19,7 @@ class RoundRobinBalancingStrategy : public FailOverRequestBalancingStrategy
 
   private:
     std::vector<transport::InetSocketAddress> servers;
+    sys::Mutex lock;
     size_t index;
 
     const transport::InetSocketAddress& getServerByIndex(size_t pos);

--- a/src/hotrod/impl/transport/tcp/TcpTransportFactory.cpp
+++ b/src/hotrod/impl/transport/tcp/TcpTransportFactory.cpp
@@ -101,8 +101,6 @@ transport::Transport& TcpTransportFactory::getTransport(const std::vector<char>&
 transport::Transport& TcpTransportFactory::getTransport(const std::vector<char>& key, const std::vector<char>& cacheName, const std::set<transport::InetSocketAddress>& failedServers) {
     InetSocketAddress server;
     {
-        ScopedLock<Mutex> l(lock);
-
         server = topologyInfo->getHashAwareServer(key,cacheName);
         if (server.isEmpty())
         {   // Return balanced transport
@@ -202,7 +200,6 @@ bool TcpTransportFactory::isTcpNoDelay() {
 }
 
 int TcpTransportFactory::getMaxRetries() {
-    ScopedLock<Mutex> l(lock);
     return maxRetries;
 }
 
@@ -287,7 +284,6 @@ Transport& TcpTransportFactory::borrowTransportFromPool(
 
 ConnectionPool* TcpTransportFactory::getConnectionPool()
 {
-    ScopedLock<Mutex> l(lock);
     return connectionPool.get();
 }
 


### PR DESCRIPTION
Removed locks in the TcpTransportFactory because deadlock with the mutex in BlockingQueue class

https://issues.jboss.org/browse/HRCPP-485