### PR TITLE
HRCPP-489 No fail if googletest has problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,13 +56,15 @@ execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
   RESULT_VARIABLE result
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
 if(result)
-  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+  message(WARNING "Build step for googletest failed: ${result}")
+  message(WARNING "If you don't need the xunit test suite, this should be ok.")
 endif()
 execute_process(COMMAND ${CMAKE_COMMAND} --build .
   RESULT_VARIABLE result
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
 if(result)
-  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+  message(WARNING "Build step for googletest failed: ${result}")
+  message(WARNING "If you don't need the xunit test suite, this should be ok.")
 endif()
 
 # Prevent overriding the parent project's compiler/linker

--- a/jni/swig.cmake
+++ b/jni/swig.cmake
@@ -20,7 +20,8 @@ include(UseSWIG)
 
 find_program(MVN_PROGRAM "mvn")
 if (MVN_PROGRAM STREQUAL "MVN_PROGRAM-NOTFOUND")
-    message(FATAL_ERROR "Apache Maven (mvn) not found in path")
+    message(WARNING "Apache Maven (mvn) not found in path")
+    message(WARNING "If you don't need the xunit test suite, this should be ok.")
 endif (MVN_PROGRAM STREQUAL "MVN_PROGRAM-NOTFOUND")
 
 if(WIN32 AND NOT CYGWIN)


### PR DESCRIPTION
cmake configuration now continues if googletest can't be build.

https://issues.jboss.org/browse/HRCPP-489