### PR TITLE
HRCPP-499 configurable act on pool exhausted and test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,11 @@ if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set (WERROR "-Werror")
   endif (ENABLE_WARNING_ERROR)
 
-  set (COMPILER_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden -std=c++11")
+  if (ENABLE_INTERNAL_TESTS OR ENABLE_ADDITIONAL_TESTS)
+      set (COMPILER_FLAGS "-std=c++11")
+  else (ENABLE_INTERNAL_TESTS OR ENABLE_ADDITIONAL_TESTS)
+      set (COMPILER_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden -std=c++11")
+  endif (ENABLE_INTERNAL_TESTS OR ENABLE_ADDITIONAL_TESTS)
   if (DEFINED CODE_COVERAGE)
         set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-modules)
         include(CodeCoverage)
@@ -223,9 +227,11 @@ if(WIN32 AND NOT CYGWIN)
   set (NOENABLE_VALGRIND ON)
 endif(WIN32 AND NOT CYGWIN)
 
+set (NOENABLE_ADDITIONAL_TESTS ON)
+
 # Add options here called <whatever> they will turn into "ENABLE_<whatever" and can be
 # overridden on a platform specific basis above by NOENABLE_<whatever>
-set (OPTIONS UNDEFINED_ERROR SWIG_TESTING INTERNAL_TESTING VALGRIND)
+set (OPTIONS UNDEFINED_ERROR SWIG_TESTING INTERNAL_TESTING VALGRIND ADDITIONAL_TESTS)
 
 foreach (OPTION ${OPTIONS})
   if (NOT "NOENABLE_${OPTION}")
@@ -239,6 +245,7 @@ option(ENABLE_UNDEFINED_ERROR "Check for unresolved library symbols" ${DEFAULT_U
 option(ENABLE_SWIG_TESTING "Create SWIG Java binding and test structure" ${DEFAULT_SWIG_TESTING})
 option(ENABLE_INTERNAL_TESTING "Compile the library with internal tests (unit tests)" ${DEFAULT_INTERNAL_TESTING})
 option(ENABLE_VALGRIND "Enable running the tests using Valgrind" ${DEFAULT_VALGRIND})
+option(NO_ENABLE_ADDITIONAL_TESTS "Enable running tests that require full visibility on the hotrod library" ${DEFAULT_ADDITIONAL_TESTS})
 
 if(DEFINED HOTROD_PREBUILT_LIB_DIR)
     set(PROTOBUF_GENERATE_CPP_APPEND_PATH true)
@@ -522,6 +529,19 @@ add_dependencies(build_native_test unittest unittest-static simple simple-static
 
 # TESTS
 
+if (DEFINED ENABLE_ADDITIONAL_TESTS)  # Compile a version with all symbols for additional tests with gcc
+    add_executable (poolUnitTest test/PoolUnitTest.cpp)
+    target_include_directories(poolUnitTest PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
+                                         "${INCLUDE_FILES_DIR}"
+                                         "${CMAKE_CURRENT_BINARY_DIR}"
+                                         "${PROTOBUF_INCLUDE_DIR}")
+    set_property(TARGET poolUnitTest PROPERTY CXX_STANDARD 11)
+    set_property(TARGET poolUnitTest PROPERTY CXX_STANDARD_REQUIRED ON)
+    set_target_properties(poolUnitTest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}")
+    set_target_properties (poolUnitTest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${NO_UNUSED_FLAGS}")
+    target_link_libraries (poolUnitTest hotrod hotrod_protobuf ${PROTOBUF_LIBRARY} ${platform_libs})
+endif (DEFINED ENABLE_ADDITIONAL_TESTS)
+
 add_executable (simple test/Simple.cpp)
 target_include_directories(simple PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
                                      "${INCLUDE_FILES_DIR}"
@@ -543,6 +563,17 @@ set_property(TARGET simple-static PROPERTY CXX_STANDARD_REQUIRED ON)
 set_target_properties (simple-static PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${STATIC_FLAGS} ${NO_UNUSED_FLAGS}")
 set_target_properties(simple-static PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}" )
 target_link_libraries (simple-static hotrod-static hotrod_protobuf ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${platform_libs})
+
+add_executable (poolTest test/PoolTest.cpp)
+target_include_directories(poolTest PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
+                                     "${INCLUDE_FILES_DIR}"
+                                     "${CMAKE_CURRENT_BINARY_DIR}"
+                                     "${PROTOBUF_INCLUDE_DIR}")
+set_property(TARGET poolTest PROPERTY CXX_STANDARD 11)
+set_property(TARGET poolTest PROPERTY CXX_STANDARD_REQUIRED ON)
+set_target_properties(poolTest PROPERTIES COMPILE_DEFINITIONS "${DLLEXPORT_STATIC}")
+set_target_properties (poolTest PROPERTIES COMPILE_FLAGS "${COMPILER_FLAGS} ${WARNING_FLAGS_NO_PEDANTIC} ${NO_UNUSED_FLAGS}")
+target_link_libraries (poolTest hotrod hotrod_protobuf ${PROTOBUF_LIBRARY} ${platform_libs})
 
 add_executable (queryTest test/QueryTest.cpp ${TEST_PROTO_SRCS})
 target_include_directories(queryTest PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/test/query_proto"
@@ -777,6 +808,9 @@ if (ENABLE_INTERNAL_TESTING)
     add_test (unittest-static unittest-static)
 endif (ENABLE_INTERNAL_TESTING)    
 
+if (DEFINED ENABLE_ADDITIONAL_TESTS)  # Run unit tests that require full symbols visibility
+    add_test (poolUnitTest poolUnitTest)
+endif (DEFINED ENABLE_ADDITIONAL_TESTS)
 
 find_program(MVN_PROGRAM "mvn")
 if (MVN_PROGRAM STREQUAL "MVN_PROGRAM-NOTFOUND")
@@ -825,6 +859,7 @@ else (NOT ((EXISTS "${HOTROD_JBOSS_HOME}/bin/standalone.sh") AND (EXISTS "${HOTR
     add_test (continuousQueryTest-static continuousQueryTest-static)
     add_test (simpleTx simpleTx)
     add_test (simpleTx-static simpleTx-static)
+    add_test (poolTest poolTest)
     add_test (simple-mediatype simple 2.8)
     add_test (simple-static-mediatype simple-static 2.8)
     add_test (queryTest-mediatype queryTest 2.8)

--- a/include/infinispan/hotrod/JBossMarshaller.h
+++ b/include/infinispan/hotrod/JBossMarshaller.h
@@ -43,6 +43,8 @@ public:
 };
 
 template<> inline int* JBossMarshaller::unmarshall(const std::vector<char>& b) {
+    if (b.begin()==b.end())
+        return nullptr;
     int result = 0;
     for (int i = 0; i < 4; i++) {
         result <<= 8;
@@ -54,6 +56,8 @@ template<> inline int* JBossMarshaller::unmarshall(const std::vector<char>& b) {
 
 template<> inline std::string* JBossMarshaller::unmarshall(const std::vector<char>& b) {
     // TODO: this works only for SMALL_STRING
+    if (b.begin()==b.end())
+        return nullptr;
     std::string* s = new std::string(b.begin() + 3, b.end());
     return s;
 }

--- a/include/infinispan/hotrod/exceptions.h
+++ b/include/infinispan/hotrod/exceptions.h
@@ -162,6 +162,11 @@ public:
     std::string name;
 };
 
+class HR_EXTERN NoSuchElementException: public Exception {
+public:
+	NoSuchElementException(const std::string& msg) : Exception(msg) { }
+};
+
 }
 } // namespace
 

--- a/jni/pom.xml
+++ b/jni/pom.xml
@@ -149,12 +149,16 @@
          <version>${version.org.testng}</version>
          <scope>test</scope>
       </dependency>
-            <dependency>
+      <dependency>
          <groupId>org.mockito</groupId>
          <artifactId>mockito-core</artifactId>
          <version>1.10.19</version>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>javax.annotation</groupId>
+         <artifactId>javax.annotation-api</artifactId>
+         <version>1.3.1</version>
+      </dependency>
    </dependencies>
-
 </project>

--- a/src/hotrod/impl/transport/tcp/ConnectionPool.cpp
+++ b/src/hotrod/impl/transport/tcp/ConnectionPool.cpp
@@ -89,51 +89,52 @@ bool ConnectionPool::tryRemoveIdleOrAskAllocate(const InetSocketAddress& key) {
 }
 
 TcpTransport& ConnectionPool::borrowObject(const InetSocketAddress& key) {
-	sys::ScopedLock<sys::Mutex> l(lock);
+    sys::ScopedLock<sys::Mutex> l(lock);
 
-	if (closed) {
-		throw HotRodClientException("Pool is closed");
-	}
-	if (!idle.count(key) || !busy.count(key)) {
-		throw HotRodClientException("Pool has no idle or no busy transports.");
-	}
-	TransportQueuePtr idleQ = idle[key];
-	TransportQueuePtr busyQ = busy[key];
+    if (closed) {
+        throw HotRodClientException("Pool is closed");
+    }
+    if (!idle.count(key) || !busy.count(key)) {
+        throw HotRodClientException("Pool has no idle or no busy transports.");
+    }
+    TransportQueuePtr idleQ = idle[key];
+    TransportQueuePtr busyQ = busy[key];
 
-	// See if an object is readily available
-	TcpTransport* obj = NULL;
-	bool ok = idleQ->poll(obj);
-	if (ok) {
-		totalIdle--;
-	}
-	// Loop for a valid object in the pool
-	while (obj == NULL
-			|| (configuration.isTestOnBorrow()
-					&& !factory->validateObject(key, *obj))) {
-		// obj is invalid here
-		if (obj != NULL) {
-			factory->destroyObject(key, *obj);
-		}
-		// See if we can create a new one
-		if (idleQ->size() == 0 	             // if the idle queue is empty
-				&& 	                         // and queue has space
-				(configuration.getMaxActive() < 0
-						|| busyQ->size() < (size_t) configuration.getMaxActive())
-				&& 				             // and there space for other objs or it can be freed
-				(!hasReachedMaxTotal() || tryRemoveIdleOrAskAllocate(key))) {
-			obj = &factory->makeObject(key); // then create new object
-		} else {
-			sys::ScopedUnlock<sys::Mutex> u(lock);
-			obj = idleQ->pop();  			 // else wait for the first available
-			totalIdle--;
-		}
-	}
+    // See if an object is readily available
+    TcpTransport* obj = NULL;
+    bool ok = idleQ->poll(obj);
+    if (ok) {
+        totalIdle--;
+    }
+    // Loop for a valid object in the pool
+    while (obj == NULL || (configuration.isTestOnBorrow() && !factory->validateObject(key, *obj))) {
+        // obj is invalid here
+        if (obj != NULL) {
+            factory->destroyObject(key, *obj);
+        }
+        // See if we can create a new one
+        if (idleQ->size() == 0               // if the idle queue is empty
+        &&// and queue has space
+                (configuration.getMaxActive() < 0 || busyQ->size() < (size_t) configuration.getMaxActive()) && // and there space for other objs or it can be freed
+                (!hasReachedMaxTotal() || tryRemoveIdleOrAskAllocate(key))) {
+            obj = &factory->makeObject(key); // then create new object
+        } else {
+            sys::ScopedUnlock<sys::Mutex> u(lock);
+            if (this->getConfiguration().getExhaustedAction() == EXCEPTION) {
+                obj = idleQ->popOrThrow();   // else wait for the first available
+            } else {
+                obj = idleQ->pop();          // else wait for the first available
+            }
 
-	busyQ->push(obj);
-	totalActive++;
+            totalIdle--;
+        }
+    }
 
-	factory->activateObject(key, *obj);
-	return *obj;
+    busyQ->push(obj);
+    totalActive++;
+
+    factory->activateObject(key, *obj);
+    return *obj;
 }
 
 void ConnectionPool::invalidateObject(const InetSocketAddress& key, TcpTransport* val) {

--- a/src/hotrod/sys/BlockingQueue.h
+++ b/src/hotrod/sys/BlockingQueue.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include "hotrod/sys/Condition.h"
 #include "hotrod/sys/Mutex.h"
+#include "infinispan/hotrod/exceptions.h"
 
 namespace infinispan {
 namespace hotrod {
@@ -45,6 +46,17 @@ public:
 
         while (queue.empty()) {
             condition.wait(lock);
+        }
+        T element = queue.front();
+        queue.pop_front();
+        return element;
+    }
+
+    T popOrThrow() {
+        ScopedLock<Mutex> l(lock);
+
+        if (queue.empty()) {
+            throw infinispan::hotrod::NoSuchElementException("Reached maximum number of connections");
         }
         T element = queue.front();
         queue.pop_front();

--- a/test/PoolTest.cpp
+++ b/test/PoolTest.cpp
@@ -1,0 +1,163 @@
+#include "infinispan/hotrod/ConfigurationBuilder.h"
+#include "infinispan/hotrod/RemoteCacheManager.h"
+#include "infinispan/hotrod/RemoteCache.h"
+#include "infinispan/hotrod/Version.h"
+
+#include "infinispan/hotrod/JBasicMarshaller.h"
+#include "infinispan/hotrod/JBossMarshaller.h"
+#include <stdlib.h>
+#include <iostream>
+#include <memory>
+#include <typeinfo>
+#include <thread>
+#include <future>
+#include <chrono>
+
+// For CTest: return 0 if all tests pass, non-zero otherwise.
+
+using namespace infinispan::hotrod;
+
+// Some useful global variables
+std::string keyName("keyName"), keyVal("keyValue");
+std::string expected[50];
+
+// Install scripts and populate the cache
+void prepareCache(RemoteCache<std::string, std::string> cache0) {
+    std::string script(
+            "// mode=local, language=javascript, parameters=[keyName]\nvar now = new Date().getTime();\n  while(new Date().getTime() < now + (250)){}\nvar cache = cacheManager.getCache(\"namedCache\");\ncache.get(keyName)\n");
+    auto execution = cache0.getRemoteExecution<>();
+    execution.putScript("get.js", script);
+    std::string putStr(
+            "// mode=local, language=javascript, parameters=[keyValue, keyName, num]\nvar cache = cacheManager.getCache(\"namedCache\");\ncache.put(keyName, keyValue);\n");
+    execution.putScript("put.js", putStr);
+    for (int i = 0; i < 50; i++) {
+        std::string k = "k" + std::to_string(i);
+        expected[i] = "v" + std::to_string(i);
+        execution.addArg(keyName, k);
+        execution.addArg(keyVal, expected[i]);
+        execution.template execute<std::string*>("put.js");
+    }
+}
+
+std::string* doSlowGet(RemoteCache<std::string, std::string> cache0, int i) {
+    auto execution = cache0.getRemoteExecution<>();
+    std::string keyVal("k" + std::to_string(i));
+    execution.addArg(keyName, keyVal);
+    return execution.template execute<std::string*>("get.js");
+}
+
+int main(int argc, char **argv) {
+    int result = 0;
+    {
+        std::cout << "Test pool with WAIT condition" << std::endl;
+        // Cache configuration
+        ConfigurationBuilder builder;
+        builder.protocolVersion(Configuration::PROTOCOL_VERSION_24);
+        builder.addServer().host("127.0.0.1").port(11222);
+        builder.balancingStrategyProducer(nullptr);
+        RemoteCacheManager cacheManager(builder.build(), false);
+        cacheManager.start();
+
+        BasicMarshaller<std::string> *km = new BasicMarshaller<std::string>();
+        BasicMarshaller<std::string> *vm = new BasicMarshaller<std::string>();
+        RemoteCache<std::string, std::string> cache0 = cacheManager.getCache<std::string, std::string>(km,
+                &Marshaller<std::string>::destroy, vm, &Marshaller<std::string>::destroy, "namedCache", false);
+
+        prepareCache(cache0);
+
+        // Start 50 threads and see if everything works.
+        // With the WAIT setup the threads have to wait if the
+        // pool is exhausted
+        std::string *res[50];
+        std::thread t[50];
+        std::promise<void> p[50];
+        for (int i = 0; i < 50; i++) {
+            t[i] = std::thread([&res, &p, &cache0, i]() {
+                res[i] = doSlowGet(cache0, i);
+                p[i].set_value();
+            });
+        }
+
+        for (int i = 0; i < 50; i++) {
+            p[i].get_future().wait();
+            if (*res[i] != expected[i]) {
+                std::cout << "FAIL: value doesn't match for index " << i << std::endl;
+                return 1;
+            }
+        }
+        std::cout << "PASS: test pool with WAIT condition" << std::endl;
+        for (int i = 0; i < 50; i++) {
+            t[i].join();
+        }
+        cacheManager.stop();
+    }
+    if (result != 0)
+        return result;
+    {
+        std::cout << "Test pool with EXCEPTION condition" << std::endl;
+        // Cache configuration
+        ConfigurationBuilder builder;
+        builder.protocolVersion(Configuration::PROTOCOL_VERSION_24);
+        builder.addServer().host("127.0.0.1").port(11222);
+        builder.balancingStrategyProducer(nullptr);
+        builder.connectionPool().exhaustedAction(EXCEPTION);
+        RemoteCacheManager cacheManager(builder.build(), false);
+        cacheManager.start();
+
+        BasicMarshaller<std::string> *km = new BasicMarshaller<std::string>();
+        BasicMarshaller<std::string> *vm = new BasicMarshaller<std::string>();
+        RemoteCache<std::string, std::string> cache0 = cacheManager.getCache<std::string, std::string>(km,
+                &Marshaller<std::string>::destroy, vm, &Marshaller<std::string>::destroy);
+
+        for (int i = 0; i < 50000; i++) {
+            cache0.put("k" + std::to_string(i), "v" + std::to_string(i));
+        }
+
+        // Start 50 threads and see if everything works.
+        // With the EXCEPTION setup the user code must implement
+        // a recover policy if pool is exhausted, this test just waits
+        // for 1 sec and retry
+        std::string *res[50];
+        std::thread t[50];
+        std::promise<void> p[50];
+        int exceptionsCaught = 0;
+        for (int i = 0; i < 50; i++) {
+            t[i] = std::thread([&res, &p, &cache0, i, &exceptionsCaught]() {
+                bool done = false;
+                while (!done) {
+                    try {
+                        res[i] = doSlowGet(cache0, i);
+                        p[i].set_value();
+                        done = true;
+                    } catch (NoSuchElementException &ex) {
+                        exceptionsCaught++;
+                        std::this_thread::sleep_for(std::chrono::seconds(1));
+                    }
+                }
+            });
+        }
+        for (int i = 0; i < 50; i++) {
+            auto status = p[i].get_future().wait_for(std::chrono::seconds(30));
+            if (status != std::future_status::ready) {
+                std::cerr << "FAIL: Timeout waiting for results " << std::endl;
+                exit(1); // Test failed just stop immediately
+            }
+            if (*res[i] != expected[i]) {
+                std::cerr << "FAIL: value doesn't match for index: " << i << std::endl;
+                exit(1); // Test failed just stop immediately
+            }
+        }
+        std::cout << "Exceptions caught by the user: " << exceptionsCaught << std::endl;
+        if (*res[20] != *doSlowGet(cache0, 20)) {
+            std::cerr << "FAIL: value doesn't match for last get" << std::endl;
+
+        }
+        std::cout << "PASS: test pool with EXCEPTION condition" << std::endl;
+        for (int i = 0; i < 50; i++) {
+            t[i].join();
+        }
+        cacheManager.stop();
+    }
+    return 0;
+}
+

--- a/test/PoolUnitTest.cpp
+++ b/test/PoolUnitTest.cpp
@@ -1,0 +1,135 @@
+#include <infinispan/hotrod/Configuration.h>
+#include "infinispan/hotrod/ConfigurationBuilder.h"
+#include <infinispan/hotrod/ConnectionPoolConfigurationBuilder.h>
+#include <hotrod/impl/transport/tcp/ConnectionPool.h>
+#include <hotrod/impl/transport/tcp/TransportObjectFactory.h>
+
+#include <iostream>
+#include <thread>
+#include <future>
+#include <chrono>
+
+using namespace infinispan::hotrod::transport;
+using namespace infinispan::hotrod::operations;
+
+
+// Basic MOC to run the unit tests
+class TestTransport: public TcpTransport {
+public:
+	TestTransport() :
+			TcpTransport() {
+	}
+};
+
+TestTransport arrayOfT[20];
+InetSocketAddress addr;
+int flag;
+
+class PoolTestObjectFactory: public AbstractObjectFactory {
+public:
+	int count = 0;
+	virtual TcpTransport& makeObject(const InetSocketAddress& address) {
+		return arrayOfT[count++];
+	}
+	virtual void destroyObject(const InetSocketAddress& address,
+			TcpTransport& transport) {
+	}
+	virtual operations::PingResult ping(TcpTransport& tcpTransport) {
+		return SUCCESS;
+	}
+};
+
+void releaseObject(ConnectionPool &cp) {
+	std::cout << "Releasing objects in 2 sec" << std::endl;
+	std::this_thread::sleep_for(std::chrono::seconds(2));
+	flag = 1;
+	std::cout << "Releasing objects" << std::endl;
+	cp.returnObject(addr, arrayOfT[0]);
+	cp.returnObject(addr, arrayOfT[1]);
+}
+
+// END MOC
+
+
+/* exitAfter is a basic timeout implementation */
+void exitAfter(std::promise<void> &p, std::chrono::duration<int64_t> d,
+		int &retVal) {
+	auto status = p.get_future().wait_for(d);
+	if (status != std::future_status::ready) {
+		std::cerr << "FAIL: Timeout" << std::endl;
+		exit(1);
+	}
+	retVal = retVal ? retVal : 0;
+}
+
+/** testWait tests the pool in WAIT configuration
+ * the pool is exhausted and after 2 sec, two objects are release
+ * and borrowed again to check that everything works
+ */
+void testWait() {
+	std::cout << "Testing pool with WAIT configuration" << std::endl;
+	ConfigurationBuilder builder;
+	builder.connectionPool().exhaustedAction(WAIT).maxTotal(10);
+	Configuration conf = builder.build();
+	PoolTestObjectFactory* poolFactory = new PoolTestObjectFactory();
+	std::shared_ptr<AbstractObjectFactory> factory(poolFactory);
+	ConnectionPool cp(factory, conf.getConnectionPoolConfiguration());
+	std::thread t1(releaseObject, std::ref(cp));
+	cp.addObject(addr);
+	flag = 0;
+	while (true) {
+		cp.borrowObject(addr);
+		if (flag == 1) {
+			cp.borrowObject(addr);
+			break;
+		}
+	}
+	t1.join();
+	std::cout << "OK" << std::endl;
+}
+
+/** testExec tests the pool in EXECEPTION configuration
+ * the pool is exhausted and after the exception one object is release
+ * and borrowed again to check that everything works
+ */
+void testExec(int &retVal) {
+	std::cout << "Testing pool with EXCEPTION configuration" << std::endl;
+	ConfigurationBuilder builder;
+	builder.connectionPool().exhaustedAction(EXCEPTION).maxTotal(10);
+	Configuration conf = builder.build();
+	PoolTestObjectFactory* poolFactory = new PoolTestObjectFactory();
+	std::shared_ptr<AbstractObjectFactory> factory(poolFactory);
+	ConnectionPool cp(factory, conf.getConnectionPoolConfiguration());
+	cp.addObject(addr);
+	try {
+		while (true) {
+			cp.borrowObject(addr);
+		}
+	} catch (NoSuchElementException &ex) {
+		cp.returnObject(addr, arrayOfT[2]);
+		try {
+			cp.borrowObject(addr);
+			retVal = 0;
+			std::cout << "OK" << std::endl;
+		} catch (Exception&) {
+			retVal = 1;
+			std::cerr << "FAIL: cannot get Obj after return" << std::endl;
+		}
+	} catch (Exception&) {
+		retVal = 1;
+		std::cerr << "FAIL: unexpected exception" << std::endl;
+	}
+}
+
+int main(int argc, char** argv) {
+	std::promise<void> promiseTimeout;
+	int retVal;
+	std::thread t1(exitAfter, std::ref(promiseTimeout),
+			(std::chrono::seconds(20)), std::ref(retVal));
+	testWait();
+	testExec(retVal);
+	promiseTimeout.set_value();
+	t1.join();
+	return retVal;
+}
+


### PR DESCRIPTION
This allows the user to configure the recover policy when connection pool is exhausted:

    configurationBuilder.connectionPool().exhaustedAction(WAIT)
waits indefinitely for a connection to be returned and made available

    configurationBuilder.connectionPool().exhaustedAction(EXCEPTION)
raises a NoSuchElementException
