### PR TITLE
fix unresolved external

### DIFF
--- a/include/infinispan/hotrod/TransactionManager.h
+++ b/include/infinispan/hotrod/TransactionManager.h
@@ -23,7 +23,7 @@ enum class TransactionRemoteStatus : unsigned int;
  */
 class TransactionManager {
 public:
-    HR_EXTERN TransactionManager() : UUID(generateV4UUID()) {}
+    HR_EXTERN TransactionManager();
     /***
      * Start a transaction on this thread. All the caches of all RemoteCacheManager
      * will be involved

--- a/src/hotrod/api/TransactionManager.cpp
+++ b/src/hotrod/api/TransactionManager.cpp
@@ -100,6 +100,8 @@ void TransactionManager::cleanUpCurrentTransaction() {
     }
 }
 
+TransactionManager::TransactionManager() : UUID(generateV4UUID()) {}
+
 void TransactionManager::begin() {
     infinispan::hotrod::Transaction& currentTransaction = *getCurrentTransaction();
     // TODO: check properly the tx status


### PR DESCRIPTION
not exported method must not be used in header file.