### PR TITLE
Updated QueryRequest structure

### DIFF
--- a/include/infinispan/hotrod/Query.h
+++ b/include/infinispan/hotrod/Query.h
@@ -60,7 +60,7 @@ public:
   inline bool has_local() const { return qrp.has_local(); }
   void clear_local() { qrp.clear_local(); }
   bool local() const { return qrp.local(); }
-  void set_local(bool value) { set_local(value); }
+  void set_local(bool value) { qrp.set_local(value); }
 
   /**
    * Deprecated, use set_querystring() instead

--- a/include/infinispan/hotrod/Query.h
+++ b/include/infinispan/hotrod/Query.h
@@ -29,6 +29,7 @@ class QueryRequest
 private:
 	QueryRequestProtobuf qrp;
 public:
+  inline QueryRequest() { qrp.set_local(false); }
   inline bool has_jpqlstring() const { return qrp.has_querystring(); }
   inline bool has_querystring() const { return qrp.has_querystring(); }
 
@@ -56,6 +57,10 @@ public:
    */
   inline void set_jpqlstring(const char* value) { qrp.set_querystring(value); }
   inline void set_querystring(const char* value) { qrp.set_querystring(value); }
+  inline bool has_local() const { return qrp.has_local(); }
+  void clear_local() { qrp.clear_local(); }
+  bool local() const { return qrp.local(); }
+  void set_local(bool value) { set_local(value); }
 
   /**
    * Deprecated, use set_querystring() instead

--- a/proto/org/infinispan/query/remote/client/query.proto
+++ b/proto/org/infinispan/query/remote/client/query.proto
@@ -1,20 +1,24 @@
+/**********************************************************************************************************************
+ *                                  REMOTE QUERY RELATED PROTOBUF DEFINITIONS                                         *
+ *                                                                                                                    *
+ *         Allocated TypeId range is: [4400 .. 4599] (see org.infinispan.commons.marshall.ProtoStreamTypeIds)         *
+ *         Actually used range is: [4400 .. 4403]                                                                     *
+ *********************************************************************************************************************/
 syntax = "proto2";
 import "message-wrapping.proto";
 
 package org.infinispan.query.remote.client;
 
 /**
- * @TypeId(1000101)
+ * @TypeId(4400)
  */
 message QueryRequestProtobuf {
 
    /**
-    * The query string, expressed in Infinispan's query language (a JPA subset with full-text enhancements).
-    * NOTE: currently only a limited subset of the JPA query language is supported.
+    * The query string, in Infinispan's query language aka Ickle (a JP-QL micro-subset with full-text enhancements).
     */
    required string queryString = 1;
 
-   // NOTE: id 2 was used for sort criteria, which is now into the ORDER BY clause inside the query string
 
    /**
     * The number of matching results to skip before the first returned result.
@@ -27,14 +31,18 @@ message QueryRequestProtobuf {
    optional int32 maxResults = 4;
 
    /**
-    * Multiple, optional named parameters. Each name must occur only once.
+    * Multiple, optional, named parameters. Each name must occur only once.
     */
    repeated NamedParameter namedParameters = 5;
+   /**
+    * Whether the query is limited to the data from node that receives the request
+    */
+   optional bool local = 6;
 
    message NamedParameter {
 
       /**
-       * Parameter name.
+       * Parameter unique name.
        */
       required string name = 1;
 
@@ -46,7 +54,7 @@ message QueryRequestProtobuf {
 }
 
 /**
- * @TypeId(1000102)
+ * @TypeId(4401)
  */
 message QueryResponse {
 
@@ -67,15 +75,20 @@ message QueryResponse {
    /**
     * The list of matching results. The size should be either numResults, if no projections are used, or numResults *
     * projectionSize otherwise. If projections are used, then each group of projectionSize consecutive elements
-    * represent together a result.
+    * represent together a row from the result. We use this simple schema in order to avoid bi-dimensional arrays when
+    * projections are present.
     */
    repeated org.infinispan.protostream.WrappedMessage results = 3;
 
+   /**
+    * Total number of results that match the query. This is usually larger than numResults due to
+    * QueryRequest.startOffset and QueryRequest.maxResults.
+    */
    required int64 totalResults = 4;
 }
 
 /**
- * @TypeId(1000103)
+ * @TypeId(4402)
  */
 message FilterResult {
 
@@ -87,14 +100,13 @@ message FilterResult {
 }
 
 /**
- * @TypeId(1000104)
+ * @TypeId(4403)
  */
 message ContinuousQueryResult {
 
-   /* @TypeId(1000105) */
    enum ResultType {
-      JOINING = 1;
       LEAVING = 0;
+      JOINING = 1;
       UPDATED = 2;
    }
 
@@ -102,9 +114,9 @@ message ContinuousQueryResult {
 
    required bytes key = 2;
 
-   /* Only present if resultType is JOINING or UPDATED and projection is missing */
+   /* Only present if resultType is JOINING or UPDATED and 'projection' field is missing */
    optional bytes value = 3;
 
-   /* Only present if jresultType is JOINING or UPDATED and value is missing */
+   /* Only present if resultType is JOINING or UPDATED and 'value' field is missing */
    repeated org.infinispan.protostream.WrappedMessage projection = 4;
 }

--- a/src/hotrod/api/RemoteCacheBase.cpp
+++ b/src/hotrod/api/RemoteCacheBase.cpp
@@ -1,5 +1,3 @@
-
-
 #include "infinispan/hotrod/RemoteCacheBase.h"
 #include "infinispan/hotrod/RemoteCacheManager.h"
 #include "hotrod/impl/RemoteCacheImpl.h"
@@ -395,7 +393,9 @@ std::vector<unsigned char> RemoteCacheBase::base_query_char(std::vector<unsigned
 {
 	QueryRequest req;
 	req.ParseFromArray(qr.data(),(int)size);
-
+	if (!req.has_local()) {
+		req.set_local(false);
+	}
 	QueryResponse resp= IMPL->query(req);
 
 	int respSize = resp.ByteSizeLong();


### PR DESCRIPTION
A new field `local` has been added to the QueryRequest class server  side.
This PR:
- sync .proto definition with the java one
- sets default value for local on the client side
- updates method base_query_char (used by C#)