### PR TITLE
fix for jdk 11 and openssl < 1.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -802,6 +802,13 @@ else (NOT ((EXISTS "${HOTROD_JBOSS_HOME}/bin/server.sh") AND (EXISTS "${HOTROD_J
         add_test (stop_krbserver ${MVN_PROGRAM} ${MVN_SETTINGS_FILE_OPT} -f krbserver/pom.xml exec:java -Dexec.mainClass=krbserver.Server -Dexec.args=stop)
     endif(WIN32)
     add_test (start_ssl_server ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/server_ctl.py start ${Java_JAVA_EXECUTABLE} ${HOTROD_JBOSS_HOME} infinispan-ssl.xml)
+    if(OPENSSL_VERSION VERSION_LESS "1.1.1")
+        set_tests_properties(start_ssl_server PROPERTIES
+            ENVIRONMENT JAVA_OPTS="-Dtest.useTLS=TLSv1.2")
+    else(OPENSSL_VERSION VERSION_LESS "1.1.1")
+        set_tests_properties(start_ssl_server PROPERTIES
+        ENVIRONMENT JAVA_OPTS="-Dtest.useTLS=TLSv1.3")
+    endif(OPENSSL_VERSION VERSION_LESS "1.1.1")
     add_test (probe_ssl_port ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)
     add_test (simple-tls simple-tls --server_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/infinispan-ca.pem)
     #    add_test (simple-tls-sni simple-tls-sni --server_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/keystore_server_cert.pem)
@@ -818,7 +825,7 @@ else (NOT ((EXISTS "${HOTROD_JBOSS_HOME}/bin/server.sh") AND (EXISTS "${HOTROD_J
 	#    add_test (simple-tls-sni-client-auth simple-tls-sni --server_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/keystore_server_cert.pem --client_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/truststore_client.p12 --protocol_version 2.8)
         add_test (simple-tls-client-auth-mediatype simple-tls --server_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/infinispan-ca.pem --client_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/truststore_client.pem --protocol_version 2.8)
         add_test (stop_ssl_server_client_auth ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/server_ctl.py stop)
-        add_test (start_sals_ssl_server ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/server_ctl.py start ${Java_JAVA_EXECUTABLE} ${HOTROD_JBOSS_HOME} infinispan-sasl-ssl.xml)
+        add_test (start_sasl_ssl_server ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/server_ctl.py start ${Java_JAVA_EXECUTABLE} ${HOTROD_JBOSS_HOME} infinispan-sasl-ssl.xml)
         add_test (probe_sasl_ssl_port ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)
         add_test (simpleSaslTls simpleSaslTls --server_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/infinispan-ca.pem --client_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/truststore_client.p12)
         add_test (stop_sasl_ssl_server ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/server_ctl.py stop)
@@ -829,7 +836,14 @@ else (NOT ((EXISTS "${HOTROD_JBOSS_HOME}/bin/server.sh") AND (EXISTS "${HOTROD_J
         #    add_test (simple-tls-client-auth-mediatype simple-tls --server_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/infinispan-ca.pem --client_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/truststore_client.pem --protocol_version 2.8)
 	#    add_test (simple-tls-sni-client-auth-mediatype simple-tls-sni --server_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/keystore_server_cert.pem --client_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/truststore_client.pem --protocol_version 2.8)
         add_test (stop_ssl_server_client_auth ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/server_ctl.py stop)
-        add_test (start_sals_ssl_server ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/server_ctl.py start ${Java_JAVA_EXECUTABLE} ${HOTROD_JBOSS_HOME} infinispan-sasl-ssl.xml)
+        add_test (start_sasl_ssl_server ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/server_ctl.py start ${Java_JAVA_EXECUTABLE} ${HOTROD_JBOSS_HOME} infinispan-sasl-ssl.xml)
+        if(OPENSSL_VERSION VERSION_LESS "1.1.1")
+            set_tests_properties(start_ssl_server PROPERTIES
+                ENVIRONMENT JAVA_OPTS="-Dtest.useTLS=TLSv1.2")
+        else(OPENSSL_VERSION VERSION_LESS "1.1.1")
+            set_tests_properties(start_ssl_server PROPERTIES
+                ENVIRONMENT JAVA_OPTS="-Dtest.useTLS=TLSv1.3")
+        endif(OPENSSL_VERSION VERSION_LESS "1.1.1")
         add_test (probe_sasl_ssl_port ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/bin/probe_port.py localhost 11222 60)
         add_test (simpleSaslTls simpleSaslTls --server_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/infinispan-ca.pem --client_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/truststore_client.pem)
         add_test (simpleSaslTls-mediatype simpleSaslTls --server_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/infinispan-ca.pem --client_cert_file ${CMAKE_CURRENT_SOURCE_DIR}/test/data/truststore_client.pem --protocol_version 2.8)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline{
             CMAKE_HOME = 'C:\\\\PROGRA~2\\\\CMake\\\\bin'
             generator = '"Visual Studio 14 2015 Win64"'
             INFINISPAN_VERSION = '11.0.9.Final'
-            JAVA_HOME = 'C:\\\\PROGRA~1\\\\JAVA\\\\JDK18~1.0_1'
+            JAVA_HOME = 'C:\\\\PROGRA~1\\\\JAVA\\\\JDK-11~1.2'
             M2_HOME = 'C:\\\\APACHE~1.9'
             MVN_PROGRAM = 'C:\\\\APACHE~1.9\\\\BIN\\\\MVN.BAT'
             PROTOBUF_INCLUDE_DIR = 'C:\\\\protobuf-3.5.2\\\\src'
@@ -41,7 +41,7 @@ pipeline{
           JBOSS_HOME = '/home/ec2-user/ispn/infinispan-server'
           M2_HOME = '/opt/maven'
           PATH = "${M2_HOME}/bin:${PATH}"
-          JAVA_HOME = '/etc/alternatives/java_sdk'
+          JAVA_HOME = '/usr/lib/jvm/java-11'
           CLIENT_VERSION="${GIT_BRANCH}"
         }
         steps {

--- a/prebuilt-tests/centos7/Dockerfile
+++ b/prebuilt-tests/centos7/Dockerfile
@@ -1,34 +1,40 @@
 FROM centos:7
 
-RUN yum -y install \
-   wget \
+VOLUME [ "/artifacts" ]
+
+ENV HOTROD_IPSTACK=IPV4
+ENV JAVA_HOME=/usr/lib/jvm/java-11
+
+RUN yum -y update && \
+   yum -y install \
    cmake \
-   iputils \
-   java-1.8.0-openjdk-devel \
-   openssl-devel \
-   rpmdevtools \
-   tar \
-   valgrind \
-   maven \
-   sudo \
-   protobuf-devel \
    cyrus-sasl-devel \
    cyrus-sasl-plain \
    cyrus-sasl-md5 \
    cyrus-sasl-gssapi \
-   krb5-workstation && \
-   yum -y groupinstall "Development Tools"
+   iputils \
+   java-11-openjdk-devel \
+   krb5-workstation \
+   maven \
+   openssl-devel \
+   procps-ng \
+   protobuf \
+   protobuf-compiler \
+   protobuf-devel \
+   rpmdevtools \
+   valgrind \
+   wget && \
+   yum groups mark convert && \
+   yum -y group install "Development Tools" && \
+   yum clean all && \
+   rm -rf /var/cache/yum
 
 #RUN wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo
 #RUN yum -y install apache-maven
 
-RUN yum -y install which && \
-   yum clean all
 
-RUN useradd -ms /bin/bash jboss
-RUN usermod -aG wheel jboss
-
-RUN echo 'jboss ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers
+RUN groupadd -r jboss -g 1000 && useradd -u 1000 -r -g jboss -m -d /home/jboss -s /sbin/nologin -c "JBoss user" jboss && \
+   chmod 755 /home/jboss
 
 # Set the working directory to jboss' user home directory
 WORKDIR /home/jboss

--- a/prebuilt-tests/centos8/Dockerfile
+++ b/prebuilt-tests/centos8/Dockerfile
@@ -1,37 +1,40 @@
-FROM centos:8
+FROM centos:stream8
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11
 
 RUN yum -y install 'dnf-command(config-manager)'
-RUN yum config-manager --set-enabled PowerTools
-RUN yum -y install \
-   wget \
+RUN yum config-manager --set-enabled powertools
+RUN dnf -y update && \
+   dnf -y install \
    cmake \
-   iputils \
-   java-1.8.0-openjdk-devel \
-   openssl-devel \
-   rpmdevtools \
-   tar \
-   valgrind \
-   maven \
-   sudo \
-   protobuf-devel \
    cyrus-sasl-devel \
    cyrus-sasl-plain \
    cyrus-sasl-md5 \
    cyrus-sasl-gssapi \
-   krb5-workstation doxygen python3 && \
-   yum -y groupinstall "Development Tools"
+   drpm \
+   iputils \
+   java-11-openjdk-devel \
+   krb5-workstation \
+   maven \
+   openssl-devel \
+   procps-ng \
+   protobuf \
+   protobuf-devel \
+   python3 \
+   rpmdevtools \
+   valgrind \
+   wget \
+   yum-utils && \
+   dnf -y group install "Development Tools" && \
+   dnf clean all && \
+   rm -rf /var/cache/yum
 
 #RUN wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo
 #RUN yum -y install apache-maven
 
-RUN yum -y install which && \
-   yum clean all
 
-RUN useradd -ms /bin/bash jboss
-
-RUN usermod -aG wheel jboss
-
-RUN echo 'jboss ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers
+RUN groupadd -r jboss -g 1000 && useradd -u 1000 -r -g jboss -m -d /home/jboss -s /sbin/nologin -c "JBoss user" jboss && \
+   chmod 755 /home/jboss
 
 # Set the working directory to jboss' user home directory
 WORKDIR /home/jboss

--- a/test/data/infinispan-sasl-ssl.xml
+++ b/test/data/infinispan-sasl-ssl.xml
@@ -56,6 +56,7 @@
                <server-identities>
                   <ssl>
                      <keystore path="keystore.jks" relative-to="infinispan.server.config.path" keystore-password="secret"/>
+		     <engine enabled-protocols="${test.useTLS:TLSv1.2}"/>
                   </ssl>
                </server-identities>
                <truststore-realm path="truststore.jks" relative-to="infinispan.server.config.path" keystore-password="secret"/>

--- a/test/data/infinispan-ssl.xml
+++ b/test/data/infinispan-ssl.xml
@@ -31,6 +31,7 @@
                   <ssl>
                      <keystore path="keystore.jks" relative-to="infinispan.server.config.path"
                                keystore-password="secret" alias="hotrod" key-password="secret"/>
+		     <engine enabled-protocols="${test.useTLS:TLSv1.2}"/>
                   </ssl>
                </server-identities>
             </security-realm>


### PR DESCRIPTION
fixed cmake to run infinispan with tls1.2 when openssl<1.1.1
plus aligned Dockerfile with downstream