### PR TITLE
Minor docs fixes

### DIFF
--- a/documentation/asciidoc/topics/attributes/community-attributes.adoc
+++ b/documentation/asciidoc/topics/attributes/community-attributes.adoc
@@ -14,4 +14,4 @@
 :doc_home: https://infinispan.org/documentation/
 :download_url: https://infinispan.org/hotrod-clients
 :cli_docs: https://infinispan.org/docs/stable/titles/cli/cli.html
-:cpp_api_docs: https://infinispan.org/hotrod-clients
+:cpp_api_docs: https://infinispan.org/docs/hotrod-clients/cpp/docs/9.1.0.Final/api_docs/html/index.html

--- a/documentation/asciidoc/topics/proc_compiling_protobuf_nix.adoc
+++ b/documentation/asciidoc/topics/proc_compiling_protobuf_nix.adoc
@@ -6,7 +6,7 @@ Compile Protobuf schema, `.proto` files, into C{plusplus} header and source file
 
 * Install the Protobuf library and `protobuf-devel` package.
 +
-[source,bash,options="nowrap",subs=attributes+]
+[source,options="nowrap",subs=attributes+]
 ----
 # yum install protobuf
 # yum install protobuf-devel
@@ -16,14 +16,14 @@ Compile Protobuf schema, `.proto` files, into C{plusplus} header and source file
 
 . Set the `LD_LIBRARY_PATH` environment variable, if it is not already set.
 +
-[source,bash,options="nowrap",subs=attributes+]
+[source,options="nowrap",subs=attributes+]
 ----
 # export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/lib64
 ----
 +
 . Compile Protobuf schema for the {hr_cpp} client as required.
 +
-[source,bash,options="nowrap",subs=attributes+]
+[source,options="nowrap",subs=attributes+]
 ----
 # /bin/protoc --cpp_out dllexport_decl=HR_PROTO_EXPORT:/path/to/output/ $FILE
 ----

--- a/documentation/asciidoc/topics/proc_compiling_protobuf_win.adoc
+++ b/documentation/asciidoc/topics/proc_compiling_protobuf_win.adoc
@@ -7,7 +7,7 @@ Compile Protobuf schema, `.proto` files, into C{plusplus} header and source file
 . Open a command prompt to the installation directory for the {hr_cpp} client.
 . Compile Protobuf schema for the {hr_cpp} client as required.
 +
-[source,bash,options="nowrap",subs=attributes+]
+[source,options="nowrap",subs=attributes+]
 ----
 bin\protoc --cpp_out dllexport_decl=HR_PROTO_EXPORT:path\to\output\ $FILE
 ----

--- a/documentation/asciidoc/topics/proc_installing_client_nix.adoc
+++ b/documentation/asciidoc/topics/proc_installing_client_nix.adoc
@@ -9,7 +9,7 @@ ifdef::community[]
 . Download the {hr_cpp} client from link:{download_url}[Hot Rod client downloads].
 . Install the RPM with either the `yum` package manager or `dnf` utility.
 +
-[source,bash,options="nowrap",subs=attributes+]
+[source,options="nowrap",subs=attributes+]
 ----
 # yum localinstall infinispan-hotrod-cpp-<version>-RHEL-x86_64.rpm
 ----
@@ -33,7 +33,7 @@ ifdef::downstream[]
 +
 . Install the {hr_cpp} client.
 +
-[source,bash,options="nowrap",subs=attributes+]
+[source,options="nowrap",subs=attributes+]
 ----
 # yum install jdg-cpp-client
 ----


### PR DESCRIPTION
Small fixes:

- Fix attribute with url to HR C++ api docs
- remove "bash" from code block annotations (this caused issue with syntax highlighting, the commands starting with # were commented out)

Can be merged 